### PR TITLE
Hugh/navigation redesign

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.*
-**/tsonfig.json
-**/webpack.config.js
-node_modules
-src

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,2 @@
 import '@storybook/addon-a11y/register';
 import '@storybook/addon-actions/register';
-import '@storybook/addon-knobs/register';

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.11",
+  "version": "0.1.18",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
-  "types": "dist/",
+  "types": "dist/index.d.ts",
   "homepage": "https://github.com/featherweight-design/component-library#readme",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
     "url": "https://github.com/featherweight-design/component-library/issues"
   },
   "files": [
-    "lib/**/*"
+    "dist/**/*"
   ],
   "keywords": [],
   "author": "Featherweight Design",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.10",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
+  "types": "dist/",
   "homepage": "https://github.com/featherweight-design/component-library#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "homepage": "https://github.com/featherweight-design/component-library#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@babel/preset-typescript": "^7.7.4",
     "@storybook/addon-a11y": "^5.2.8",
     "@storybook/addon-actions": "^5.2.8",
-    "@storybook/addon-knobs": "^5.2.8",
     "@storybook/addon-links": "^5.2.8",
     "@storybook/addon-storyshots": "^5.2.8",
     "@storybook/addons": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -162,7 +162,7 @@
   &-destructive,
   &-outline-destructive {
     > .fd-button__loader-container {
-      top: 0.5rem;
+      top: 0.25rem;
     }
   }
 }

--- a/src/components/ExpansionPanel/ExpansionPanel.scss
+++ b/src/components/ExpansionPanel/ExpansionPanel.scss
@@ -1,119 +1,72 @@
-.expansion-panel {
-  margin: 0;
-  margin-bottom: 0;
-  background-color: #fff;
-  box-shadow: rgba(112, 130, 156, 0.2) 0px 2px 4px 0px;
-  overflow: hidden;
-  transition: margin-bottom 0.2s ease-in-out;
-  &-show {
-    max-height: 20000px;
-    margin-bottom: 1rem;
-  }
-  &-hidden {
-    max-height: unset;
-    margin-bottom: 0;
-    border-radius: 0;
-    box-shadow: none;
-    background-color: transparent;
-  }
-  &-light {
-    max-height: unset;
-    box-shadow: none;
-    margin-bottom: 0;
-    &:first-of-type > .expansion-panel__icon {
-      margin-top: -1rem;
+@import '../../styles/main';
+
+.fd-expansion-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  &-with-title {
+    + .fd-expansion-panel::before {
+      @include gradientPseudoBorderTop;
     }
-    &:first-of-type > .expansion-panel__title {
-      margin-top: 0;
+    &:last-of-type::after {
+      @include gradientPseudoBorderBottom;
     }
-  }
-  &__title {
-    margin: 1.5rem 0;
   }
   &__button {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    padding: 0 1rem;
-    background: none;
+    justify-content: flex-start;
+    padding: 0.75rem;
     border: none;
-    border-radius: 0.25rem;
-    box-shadow: 0 -1px 18px 2px rgba(99, 115, 138, 0.1);
-    font-size: unset;
-    text-transform: capitalize;
-    cursor: pointer;
-    &-show {
-      border-bottom: solid 1px #d8dde6;
+    color: $cool-gray-19;
+    background-color: $gray-03;
+    box-shadow: $brand-color 0.25rem 0 0 inset;
+    transition: box-shadow 0.2s ease-in-out;
+    &:focus {
+      outline: none;
     }
-    &-light {
-      justify-content: flex-start;
-      align-items: center;
-      border-bottom: none;
-      box-shadow: none;
-      > .expansion-panel__title {
-        margin: 1rem 0.25rem 1rem 0;
-        color: #000;
-        font-size: 1rem;
-      }
-      > .expansion-panel__icon {
-        color: #63738a;
-      }
+    &-hidden {
+      box-shadow: $brand-color 0 0 0 inset;
     }
   }
   &__icon {
-    width: fit-content;
-    height: fit-content;
-    transition: 0.3s ease-in-out;
-    &-show {
-      transform: rotateX(180deg);
+    margin-right: 0.5rem;
+    transition: 0.2s ease-in-out;
+    &-hidden {
+      transform: rotate(-90deg);
     }
   }
-  &__child-wrapper {
+  &__title {
+    font-size: 0.75rem;
+  }
+  &__content {
     position: relative;
-    display: flex;
-    flex-direction: column;
-    max-height: 20000px;
-    opacity: 1;
-    transition: border-top 0.3s 0.4s, border-bottom 0.3s 0.4s, opacity 0.3s 0.4s,
-      max-height 0.6s ease-in-out;
-    &-show {
-      padding: 1.5rem;
-      & * {
-        max-height: 20000px;
-        visibility: visible;
-        transition: all 0.2s, visibility 0.3s 0.4s, padding 0.3s, margin 0.3s,
-          max-height 0.6s ease-in-out;
-      }
+    padding-bottom: 0.5rem;
+    max-height: 1500px;
+    visibility: visible;
+    // Opening transitions
+    transition: 0.2s ease-in-out;
+    > * {
+      max-height: 1500px;
+      opacity: 1;
+      transition: max-height 0.2s ease-in-out, opacity 0.2s ease-in-out 0.2s;
     }
-    &-light {
-      padding: 0 0.25rem;
-    }
-    &-hide {
-      max-height: 0px;
-      padding: 0;
-      opacity: 0;
-      border-bottom: 1px solid rgba(0, 0, 0, 0);
-      transition: padding 0.3s 0.3s, border-top 0.3s, border-bottom 0.3s,
-        opacity 0.3s, max-height 0.6s 0.1s ease-in-out;
-      & * {
-        max-height: 0px;
-        padding: 0 !important;
-        margin: 0 !important;
-        visibility: hidden;
-        transition: visibility 0.3s, padding 0.3s 0.4s, margin 0.3s 0.4s,
-          max-height 0.6s 0.1s ease-in-out;
+    &-closing,
+    &-hidden {
+      max-height: 0;
+      padding-bottom: 0;
+      // Closing transitions
+      transition: max-height 0.2s ease-in-out 0.1s, padding 0.2s ease-in-out;
+      > * {
+        max-height: 0;
+        opacity: 0;
+        transition: max-height 0.2s ease-in-out, opacity 0.2s ease-in-out;
       }
     }
     &-hidden {
-      padding: 0;
-      border-bottom: none;
-    }
-    &-primary {
-      background-color: #fff;
-    }
-    &-nested {
-      background-color: #f9f9f9;
+      position: absolute;
+      top: -9999px;
+      left: -9999px;
     }
   }
 }

--- a/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
@@ -8,23 +8,45 @@ import ExpansionPanel from './ExpansionPanel';
 storiesOf('Expansion Panel', module)
   .addDecorator(checkA11y)
   .add('Default', () => (
-    <ExpansionPanel title="Click Me!">
-      <p>I am some hidden text</p>
-    </ExpansionPanel>
-  ))
-  .add('With type "light"', () => (
-    <ExpansionPanel title="Some important title" type="light">
-      <p>Words</p>
-    </ExpansionPanel>
-  ))
-  .add('With a nested panel', () => (
-    <ExpansionPanel title="Nesting doll">
-      <ExpansionPanel title="Nested doll" type="nested">
-        <p>You found me!</p>
+    <div>
+      <ExpansionPanel title="Hide small things!">
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <span>🐛</span>
+          <span>🐛</span>
+          <span>🐛</span>
+          <span>🐛</span>
+          <span>🐛</span>
+        </div>
       </ExpansionPanel>
-    </ExpansionPanel>
+
+      <ExpansionPanel title="Hide medium things!">
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            fontSize: '2rem',
+          }}
+        >
+          <span>🐰</span>
+          <span>🐰</span>
+          <span>🐰</span>
+        </div>
+      </ExpansionPanel>
+
+      <ExpansionPanel title="Hide big things!">
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            fontSize: '5rem',
+          }}
+        >
+          <span>🐻</span>
+        </div>
+      </ExpansionPanel>
+    </div>
   ))
-  .add('With type "hidden"', () => {
+  .add('With no title', () => {
     const [isExpanded, toggleIsExpanded] = useState(false);
 
     return (
@@ -35,7 +57,7 @@ storiesOf('Expansion Panel', module)
         >
           Click Me!
         </Button>
-        <ExpansionPanel type="hidden" expanded={isExpanded}>
+        <ExpansionPanel expanded={isExpanded}>
           <div
             style={{
               display: 'flex',

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -1,109 +1,95 @@
 import React, {
   ReactChild,
-  MouseEvent,
-  KeyboardEvent,
-  useState,
-  useRef,
-  useEffect,
   FunctionComponent,
+  useState,
+  useEffect,
 } from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import './ExpansionPanel.scss';
 
 type ExpansionPanelProps = {
   children: ReactChild | ReactChild[];
-  expanded?: boolean;
-  type?: 'light' | 'hidden' | 'nested';
-  className?: string;
   title?: string;
-  onClick?: (event: MouseEvent | KeyboardEvent) => void;
+  expanded?: boolean;
+  className?: string;
 };
-
 const ExpansionPanel: FunctionComponent<ExpansionPanelProps> = ({
-  children,
   expanded,
-  className,
   title,
-  type,
-  onClick,
+  className,
+  children,
 }: ExpansionPanelProps) => {
-  const [isExpanded, toggleIsExpanded] = useState(expanded);
-  const expansionChildren = useRef<HTMLDivElement>(null);
+  const [isExpanded, setIsExpanded] = useState(expanded);
+  const [isClosing, setIsClosing] = useState(false);
+  const [isHidden, setIsHidden] = useState(!expanded);
 
   useEffect(() => {
-    if (expanded) {
-      setTimeout(() => getExpansionChildrenHeight(), 300);
+    if (expanded !== isExpanded) {
+      handleToggleExpansion();
     }
-
-    toggleIsExpanded(expanded);
   }, [expanded]);
 
-  const getExpansionChildrenHeight = (): number | null =>
-    expansionChildren.current && expansionChildren.current.clientHeight;
-
-  const containerClassNames = classNames({
-    [className as string]: className,
-    'expansion-panel': true,
-    'expansion-panel-show': isExpanded,
-    'expansion-panel-hide': !isExpanded,
-    'expansion-panel-no-title': !title,
-    [`expansion-panel-${type}`]: type,
-  });
-
-  const childWrapperClassName = classNames({
-    'expansion-panel__child-wrapper': true,
-    'expansion-panel__child-wrapper-show': isExpanded,
-    'expansion-panel__child-wrapper-hide': !isExpanded,
-    'expansion-panel__child-wrapper-primary': !type,
-    [`expansion-panel__child-wrapper-${type}`]: type,
-  });
-
-  const buttonClassNames = classNames({
-    'expansion-panel__button': true,
-    'expansion-panel__button-show': isExpanded,
-    'expansion-panel__button-hide': !isExpanded,
-    [`expansion-panel__button-${type}`]: type,
-  });
-
-  const iconClassNames = classNames({
-    'material-icons': true,
-    'expansion-panel__icon': true,
-    'expansion-panel__icon-show': isExpanded,
-    'expansion-panel__icon-hide': !isExpanded,
-    [`expansion-panel__icon-${type}`]: type,
-  });
+  const handleToggleExpansion = (): void => {
+    if (isExpanded) {
+      setIsClosing(true);
+      setTimeout(() => {
+        setIsClosing(false);
+        setIsHidden(true);
+      }, 500);
+    } else {
+      setIsHidden(false);
+    }
+    setIsExpanded(!isExpanded);
+  };
 
   return (
-    <div className={containerClassNames}>
+    <div
+      className={classnames({
+        'fd-expansion-panel': true,
+        'fd-expansion-panel-with-title': title,
+        [className as string]: className,
+      })}
+    >
       {title && (
         <button
-          className={buttonClassNames}
-          tabIndex={0}
-          onClick={onClick || ((): void => toggleIsExpanded(!isExpanded))}
-          onKeyDown={onClick || ((): void => toggleIsExpanded(!isExpanded))}
+          className={classnames({
+            'fd-expansion-panel__button': true,
+            'fd-expansion-panel__button-hidden': !isExpanded,
+          })}
+          aria-controls="accordion-details-01"
+          aria-expanded={isExpanded}
+          onClick={handleToggleExpansion}
         >
-          <h4 className="expansion-panel__title">{title}</h4>
-          <i className={iconClassNames}>
-            {type === 'light' ? 'arrow_drop_down' : 'keyboard_arrow_down'}
+          <i
+            className={classnames({
+              'material-icons': true,
+              'fd-expansion-panel__icon': true,
+              'fd-expansion-panel__icon-hidden': !isExpanded,
+            })}
+          >
+            keyboard_arrow_down
           </i>
+          ​<span className="fd-expansion-panel__title">{title}</span>
         </button>
       )}
-
-      <div className={childWrapperClassName} ref={expansionChildren}>
+      ​
+      <div
+        aria-hidden={isExpanded}
+        className={classnames({
+          'fd-expansion-panel__content': true,
+          'fd-expansion-panel__content-closing': isClosing,
+          'fd-expansion-panel__content-hidden': !isExpanded && isHidden,
+        })}
+      >
         {children}
       </div>
     </div>
   );
 };
-
 ExpansionPanel.defaultProps = {
-  children: undefined,
+  title: undefined,
   expanded: false,
   className: undefined,
-  title: undefined,
-  type: undefined,
-  onClick: undefined,
 };
-
 export default ExpansionPanel;

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.scss
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.scss
@@ -1,6 +1,6 @@
 @import '../../../styles/main';
 
-.header-menu {
+.fd-header-menu {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.scss
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.scss
@@ -4,10 +4,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 5.625rem;
-  padding: 0 3rem;
+  height: 4rem;
+  padding: 0 2rem;
   border: 1px solid $gray-04;
   background-color: $white;
+  color: $cool-gray-19;
   &__left {
     display: flex;
   }
@@ -17,22 +18,16 @@
   &__location-container {
     display: flex;
     flex-direction: column;
-    margin-right: 5rem;
   }
   &__location-title {
+    margin: 0;
     font-size: 1.5rem;
     font-weight: 700;
     text-transform: capitalize;
-    &-with-subtitle {
-      margin: 0;
-      padding-top: 0.875rem;
-      padding-bottom: 0.375rem;
-    }
   }
   &__location-sub-title {
     margin: 0;
     padding: 0;
-    padding-bottom: 0.75rem;
     color: $gray-09;
     font-size: 0.875rem;
     font-weight: 500;
@@ -44,12 +39,13 @@
   }
   &__icon-container {
     position: relative;
-    margin-left: 2.375rem;
+    margin-left: 1.5rem;
   }
   &__menu-icon {
     position: relative;
     margin-left: 2.375rem;
-    font-size: 1.75rem;
+    color: $cool-gray-17;
+    font-size: 1.25rem;
     cursor: pointer;
     transition: 0.2s ease-in-out;
     &:focus {
@@ -80,10 +76,10 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    top: 0.3rem;
-    right: 0.05rem;
-    width: 0.5625rem;
-    height: 0.5625rem;
+    top: 0.2rem;
+    right: 0rem;
+    width: 0.4rem;
+    height: 0.4rem;
     border-radius: 100%;
     color: white;
     background: #ff4d4a;
@@ -92,25 +88,34 @@
   }
   &__sub-options {
     position: absolute;
-    top: 3.25rem;
-    right: 0;
+    top: 2.25rem;
+    right: -0.5rem;
     display: flex;
     flex-direction: column;
-    min-width: 17.5rem;
-    border: 1px solid $gray-10;
+    max-height: 0;
+    min-width: 16.5rem;
+    border: 0px solid transparent;
     border-radius: 4px;
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
     background-color: $white;
-    box-shadow: 0 3px 14px 2px rgba(99, 115, 138, 0.12),
-      0 8px 10px 1px rgba(99, 115, 138, 0.14),
-      0 5px 5px 0 rgba(99, 115, 138, 0.2);
     overflow: hidden;
-    z-index: 100;
+    transition: max-height 0.2s ease-in-out, border 0.01s ease-in-out 0.2s;
+    &-shown {
+      max-height: 600px;
+      border: 1px solid $gray-10;
+      box-shadow: 0 3px 14px 2px rgba(99, 115, 138, 0.12),
+        0 8px 10px 1px rgba(99, 115, 138, 0.14),
+        0 5px 5px 0 rgba(99, 115, 138, 0.2);
+      z-index: 100;
+      transition: max-height 0.2s ease-in-out, border 0.1s ease-in-out,
+        box-shadow 0.1s ease-in-out 0.1s;
+    }
   }
   &__sub-options-header {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    padding: 1.5rem 2rem;
+    padding: 1rem 1.5rem;
     border-bottom: 1px solid $gray-04;
   }
   &__sub-options-title {
@@ -123,18 +128,32 @@
     font-size: 1rem;
   }
   &__sub-option-icon {
-    margin-right: 2.625rem;
+    position: relative;
+    margin-right: 1rem;
     color: $gray-10;
+    font-size: 1rem;
+    &-selected {
+      color: $white;
+    }
+  }
+  &__sub-option-icon-background {
+    position: absolute;
+    left: 1.25rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background-color: $white;
+    &-selected {
+      background-color: $brand-color;
+    }
   }
   &__sub-option-link {
+    position: relative;
     display: flex;
     align-items: center;
     width: 100%;
-    padding: 1.25rem 2.25rem;
-    border-radius: 0.25rem;
+    padding: 1rem 1.5rem;
     box-sizing: border-box;
-    color: $black;
-    font-weight: normal !important;
     text-decoration: none;
     text-transform: capitalize;
     cursor: pointer;
@@ -157,9 +176,6 @@
       cursor: default;
       pointer-events: none;
     }
-  }
-  button[title="id"] {
-    text-transform: uppercase;
   }
 
   @keyframes spin {

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.scss
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.scss
@@ -1,6 +1,7 @@
 @import '../../../styles/main';
 
-.fd-header-menu {
+.fd-header-menu,
+.fd-header-menu-dark {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -99,6 +100,7 @@
     background: #ff4d4a;
     border: 1px solid $white;
     cursor: pointer;
+    z-index: 2;
   }
   &__sub-options {
     position: absolute;
@@ -248,4 +250,8 @@
       transform: rotate(0deg) scale(1);
     }
   }
+}
+
+.fd-header-menu-dark {
+  @include header-menu-dark;
 }

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.scss
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.scss
@@ -41,13 +41,23 @@
     position: relative;
     margin-left: 1.5rem;
   }
+  &__menu-icon-background {
+    position: absolute;
+    background-color: transparent;
+    height: 1.75rem;
+    width: 1.75rem;
+    border-radius: 50%;
+    right: -4px;
+    top: -4px;
+  }
   &__menu-icon {
     position: relative;
     margin-left: 2.375rem;
     color: $cool-gray-17;
+    opacity: 0.8;
     font-size: 1.25rem;
     cursor: pointer;
-    transition: 0.2s ease-in-out;
+    z-index: 1;
     &:focus {
       outline: none;
     }
@@ -56,7 +66,11 @@
     }
     &:hover,
     &-selected {
-      color: $brand-color;
+      color: $white;
+      opacity: 1;
+      + .fd-header-menu__menu-icon-background {
+        background-color: $brand-color;
+      }
     }
     &-settings:hover {
       animation: spin 2.5s infinite linear;
@@ -131,9 +145,11 @@
     position: relative;
     margin-right: 1rem;
     color: $gray-10;
+    opacity: 0.8;
     font-size: 1rem;
     &-selected {
       color: $white;
+      opacity: 1;
     }
   }
   &__sub-option-icon-background {
@@ -162,9 +178,10 @@
       color: $brand-color;
       background-color: $gray-03;
       text-decoration: none;
-      > .header-menu__sub-option-icon {
-        color: $brand-color;
-      }
+    }
+    &:hover > .fd-header-menu__sub-option-icon {
+      color: $brand-color;
+      opacity: 1;
     }
     &:focus {
       outline: none;

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
-import { checkA11y } from '@storybook/addon-a11y';
+import React from 'react';
+import { withA11Y } from '@storybook/addon-a11y';
 import { storiesOf } from '@storybook/react';
 
 import HeaderMenu from './HeaderMenu';
 
 storiesOf('Navigation/Header Menu', module)
-  .addDecorator(checkA11y)
+  .addDecorator(withA11Y)
   .add('Default', () => (
     <HeaderMenu
       currentlyViewing={{

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
@@ -32,8 +32,8 @@ storiesOf('Navigation/Header Menu', module)
   .add('With sub-options', () => (
     <HeaderMenu
       currentlyViewing={{
-        title: 'User Management',
-        path: '/user-management',
+        title: 'Permissions',
+        path: '/permissions',
       }}
       menuOptions={{
         settings: {

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
@@ -89,4 +89,46 @@ storiesOf('Navigation/Header Menu', module)
       }}
       defaultTitle="Dashboard"
     />
+  ))
+  .add('Dark theme', () => (
+    <HeaderMenu
+      goDark
+      currentlyViewing={{
+        title: 'Permissions',
+        path: '/permissions',
+      }}
+      menuOptions={{
+        settings: {
+          subTitle: 'Bob H.',
+          icon: 'settings',
+          subOptions: [
+            {
+              icon: 'group',
+              label: 'User Management',
+              path: '/user-management',
+              hasAccess: true,
+            },
+            {
+              icon: 'account_tree',
+              label: 'Permissions',
+              path: '/permissions',
+              hasAccess: true,
+            },
+            {
+              icon: 'mail',
+              label: 'Support',
+              path: '/support',
+              hasAccess: true,
+            },
+            {
+              icon: 'info',
+              label: 'Info',
+              path: '/info',
+              hasAccess: true,
+            },
+          ],
+        },
+      }}
+      defaultTitle="Dashboard"
+    />
   ));

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
@@ -32,9 +32,8 @@ storiesOf('Navigation/Header Menu', module)
   .add('With sub-options', () => (
     <HeaderMenu
       currentlyViewing={{
-        title: 'Lalapalooza',
-        subTitle: 'Get Wild',
-        path: '/lalapalooza',
+        title: 'User Management',
+        path: '/user-management',
       }}
       menuOptions={{
         settings: {
@@ -42,45 +41,27 @@ storiesOf('Navigation/Header Menu', module)
           icon: 'settings',
           subOptions: [
             {
-              icon: 'notifications',
-              label: 'Notification Preferences',
-              path: '/notifications/preferences',
+              icon: 'group',
+              label: 'User Management',
+              path: '/user-management',
               hasAccess: true,
             },
             {
               icon: 'account_tree',
-              label: 'Override Management',
-              path: '/override-management/id',
+              label: 'Permissions',
+              path: '/permissions',
               hasAccess: true,
             },
             {
               icon: 'mail',
-              label: 'Feature Request',
-              path: '/feature-request',
-              hasAccess: true,
-            },
-            {
-              icon: 'info',
               label: 'Support',
               path: '/support',
               hasAccess: true,
             },
             {
-              icon: 'person',
-              label: 'Profile',
-              path: `/profile/:userId`,
-              hasAccess: true,
-            },
-            {
-              icon: 'group',
-              label: 'Administration',
-              path: '/administration',
-              hasAccess: true,
-            },
-            {
-              icon: 'network_check',
-              label: 'Subscriptions',
-              path: '/subscriptions',
+              icon: 'info',
+              label: 'Info',
+              path: '/info',
               hasAccess: true,
             },
           ],

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -18,16 +18,22 @@ import './HeaderMenu.scss';
 type HeaderMenuProps = {
   currentlyViewing: CurrentlyViewing;
   menuOptions: HeaderMenuOptions;
-  onNavigate?: (currentlyViewing: CurrentlyViewing) => void;
   defaultTitle: string;
+  onNavigate?: (currentlyViewing: CurrentlyViewing) => void;
+  goDark?: boolean;
 };
+
+const getBaseClassName = (goDark: boolean | undefined): string =>
+  goDark ? 'fd-header-menu-dark' : 'fd-header-menu';
 
 const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
   currentlyViewing,
   menuOptions,
   onNavigate,
   defaultTitle,
+  goDark,
 }: HeaderMenuProps) => {
+  const [baseClassName] = useState(getBaseClassName(goDark));
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const subOptionsMenu = useRef<HTMLDivElement>(null);
 
@@ -83,14 +89,14 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
     subTitle,
   }: CurrentlyViewing): ReactElement => {
     const titleClassNames = classnames({
-      'fd-header-menu__location-title': true,
+      [`${baseClassName}__location-title`]: true,
     });
 
     return (
       <Fragment>
         <h2 className={titleClassNames}>{title || defaultTitle}</h2>
         {subTitle && (
-          <h4 className="fd-header-menu__location-sub-title">{subTitle}</h4>
+          <h4 className={`${baseClassName}__location-sub-title`}>{subTitle}</h4>
         )}
       </Fragment>
     );
@@ -105,12 +111,12 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
         const key = `${label}__${index}`;
         const isSelected = path === currentlyViewing.path;
         const subOptionClassNames = classnames({
-          'fd-header-menu__sub-option-link': true,
-          [`fd-header-menu__sub-option-link-${label
+          [`${baseClassName}__sub-option-link`]: true,
+          [`${baseClassName}__sub-option-link-${label
             .toLowerCase()
             .split(' ')
             .join('-')}`]: true,
-          'fd-header-menu__sub-option-link-selected': isSelected,
+          [`${baseClassName}__sub-option-link-selected`]: isSelected,
         });
 
         if (href) {
@@ -130,16 +136,16 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
             >
               <div
                 className={classnames({
-                  'fd-header-menu__sub-option-icon-background': true,
-                  'fd-header-menu__sub-option-icon-background-selected': isSelected,
+                  [`${baseClassName}__sub-option-icon-background`]: true,
+                  [`${baseClassName}__sub-option-icon-background-selected`]: isSelected,
                 })}
               />
 
               <i
                 className={classnames({
                   'material-icons': true,
-                  'fd-header-menu__sub-option-icon': true,
-                  'fd-header-menu__sub-option-icon-selected': isSelected,
+                  [`${baseClassName}__sub-option-icon`]: true,
+                  [`${baseClassName}__sub-option-icon-selected`]: isSelected,
                 })}
               >
                 {icon}
@@ -169,16 +175,16 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
             >
               <div
                 className={classnames({
-                  'fd-header-menu__sub-option-icon-background': true,
-                  'fd-header-menu__sub-option-icon-background-selected': isSelected,
+                  [`${baseClassName}__sub-option-icon-background`]: true,
+                  [`${baseClassName}__sub-option-icon-background-selected`]: isSelected,
                 })}
               />
 
               <i
                 className={classnames({
                   'material-icons': true,
-                  'fd-header-menu__sub-option-icon': true,
-                  'fd-header-menu__sub-option-icon-selected': isSelected,
+                  [`${baseClassName}__sub-option-icon`]: true,
+                  [`${baseClassName}__sub-option-icon-selected`]: isSelected,
                 })}
               >
                 {icon}
@@ -192,7 +198,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
       });
 
   const renderMenuOptions = (): ReactElement => (
-    <div className="fd-header-menu__menu-icon-container">
+    <div className={`${baseClassName}__menu-icon-container`}>
       {Object.keys(menuOptions).map((option, index) => {
         const key = `${option}__${index}`;
         const { icon, subOptions, subTitle, indicator, isActive } = menuOptions[
@@ -203,14 +209,14 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
 
         const menuOptionIconClassNames = classnames({
           'material-icons': true,
-          'fd-header-menu__menu-icon': true,
-          [`fd-header-menu__menu-icon-${option}`]: true,
-          'fd-header-menu__menu-icon-selected': isSelected,
+          [`${baseClassName}__menu-icon`]: true,
+          [`${baseClassName}__menu-icon-${option}`]: true,
+          [`${baseClassName}__menu-icon-selected`]: isSelected,
         });
 
         return (
           <Fragment key={key}>
-            <div className="fd-header-menu__icon-container">
+            <div className={`${baseClassName}__icon-container`}>
               <i
                 className={menuOptionIconClassNames}
                 role="menuitem"
@@ -231,14 +237,14 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
 
               <div
                 className={classnames({
-                  'fd-header-menu__menu-icon-background': true,
-                  'fd-header-menu__menu-icon-background-selected': isSelected,
+                  [`${baseClassName}__menu-icon-background`]: true,
+                  [`${baseClassName}__menu-icon-background-selected`]: isSelected,
                 })}
               />
 
               {indicator && (
                 <div
-                  className="fd-header-menu__icon-indicator"
+                  className={`${baseClassName}__icon-indicator`}
                   role="menuitem"
                   tabIndex={-1}
                   onClick={(): void => {
@@ -258,18 +264,20 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
               {subOptions && (
                 <div
                   className={classnames({
-                    'fd-header-menu__sub-options': true,
-                    'fd-header-menu__sub-options-shown':
+                    [`${baseClassName}__sub-options`]: true,
+                    [`${baseClassName}__sub-options-shown`]:
                       selectedOption === option,
                   })}
                   ref={subOptionsMenu}
                 >
-                  <div className="fd-header-menu__sub-options-header">
-                    <span className="fd-header-menu__sub-options-title">
+                  <div className={`${baseClassName}__sub-options-header`}>
+                    <span className={`${baseClassName}__sub-options-title`}>
                       {option}
                     </span>
                     {subTitle && (
-                      <span className="fd-header-menu__sub-options-sub-title">
+                      <span
+                        className={`${baseClassName}__sub-options-sub-title`}
+                      >
                         {subTitle}
                       </span>
                     )}
@@ -285,14 +293,14 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
   );
 
   return (
-    <div className="fd-header-menu">
-      <div className="fd-header-menu__left">
-        <div className="fd-header-menu__location-container">
+    <div className={`${baseClassName}`}>
+      <div className={`${baseClassName}__left`}>
+        <div className={`${baseClassName}__location-container`}>
           {currentlyViewing && renderCurrentlyViewingHeader(currentlyViewing)}
         </div>
       </div>
 
-      <div className="fd-header-menu__right">
+      <div className={`${baseClassName}__right`}>
         {menuOptions && renderMenuOptions()}
       </div>
     </div>
@@ -303,6 +311,7 @@ HeaderMenu.defaultProps = {
   menuOptions: undefined,
   onNavigate: undefined,
   defaultTitle: undefined,
+  goDark: false,
 };
 
 export default HeaderMenu;

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   useRef,
 } from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import {
   CurrentlyViewing,
@@ -82,9 +82,8 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
     title,
     subTitle,
   }: CurrentlyViewing): ReactElement => {
-    const titleClassNames = classNames({
+    const titleClassNames = classnames({
       'fd-header-menu__location-title': true,
-      'fd-header-menu__location-title-with-subtitle': subTitle,
     });
 
     return (
@@ -105,7 +104,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
       .map(({ label, icon, path, href }, index) => {
         const key = `${label}__${index}`;
         const isSelected = path === currentlyViewing.path;
-        const subOptionClassNames = classNames({
+        const subOptionClassNames = classnames({
           'fd-header-menu__sub-option-link': true,
           [`fd-header-menu__sub-option-link-${label
             .toLowerCase()
@@ -129,7 +128,20 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
                 setSelectedOption(null);
               }}
             >
-              <i className="material-icons fd-header-menu__sub-option-icon">
+              <div
+                className={classnames({
+                  'fd-header-menu__sub-option-icon-background': true,
+                  'fd-header-menu__sub-option-icon-background-selected': isSelected,
+                })}
+              />
+
+              <i
+                className={classnames({
+                  'material-icons': true,
+                  'fd-header-menu__sub-option-icon': true,
+                  'fd-header-menu__sub-option-icon-selected': isSelected,
+                })}
+              >
                 {icon}
               </i>
               {label}
@@ -155,7 +167,20 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
                 }
               }}
             >
-              <i className="material-icons fd-header-menu__sub-option-icon">
+              <div
+                className={classnames({
+                  'fd-header-menu__sub-option-icon-background': true,
+                  'fd-header-menu__sub-option-icon-background-selected': isSelected,
+                })}
+              />
+
+              <i
+                className={classnames({
+                  'material-icons': true,
+                  'fd-header-menu__sub-option-icon': true,
+                  'fd-header-menu__sub-option-icon-selected': isSelected,
+                })}
+              >
                 {icon}
               </i>
               {label}
@@ -173,7 +198,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
         const { icon, subOptions, subTitle, indicator, isActive } = menuOptions[
           option
         ] as HeaderMenuOption;
-        const menuOptionIconClassNames = classNames({
+        const menuOptionIconClassNames = classnames({
           'material-icons': true,
           'fd-header-menu__menu-icon': true,
           [`fd-header-menu__menu-icon-${option}`]: true,
@@ -220,9 +245,13 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
                   {typeof indicator === 'number' && indicator}
                 </div>
               )}
-              {subOptions && selectedOption === option && (
+              {subOptions && (
                 <div
-                  className="fd-header-menu__sub-options"
+                  className={classnames({
+                    'fd-header-menu__sub-options': true,
+                    'fd-header-menu__sub-options-shown':
+                      selectedOption === option,
+                  })}
                   ref={subOptionsMenu}
                 >
                   <div className="fd-header-menu__sub-options-header">

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -198,12 +198,14 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
         const { icon, subOptions, subTitle, indicator, isActive } = menuOptions[
           option
         ] as HeaderMenuOption;
+
+        const isSelected = selectedOption === option || isActive;
+
         const menuOptionIconClassNames = classnames({
           'material-icons': true,
           'fd-header-menu__menu-icon': true,
           [`fd-header-menu__menu-icon-${option}`]: true,
-          'fd-header-menu__menu-icon-selected':
-            selectedOption === option || isActive,
+          'fd-header-menu__menu-icon-selected': isSelected,
         });
 
         return (
@@ -226,6 +228,14 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
               >
                 {icon}
               </i>
+
+              <div
+                className={classnames({
+                  'fd-header-menu__menu-icon-background': true,
+                  'fd-header-menu__menu-icon-background-selected': isSelected,
+                })}
+              />
+
               {indicator && (
                 <div
                   className="fd-header-menu__icon-indicator"

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -2,7 +2,6 @@ import React, {
   FunctionComponent,
   ReactElement,
   Fragment,
-  SyntheticEvent,
   useState,
   useRef,
 } from 'react';

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -83,15 +83,15 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
     subTitle,
   }: CurrentlyViewing): ReactElement => {
     const titleClassNames = classNames({
-      'header-menu__location-title': true,
-      'header-menu__location-title-with-subtitle': subTitle,
+      'fd-header-menu__location-title': true,
+      'fd-header-menu__location-title-with-subtitle': subTitle,
     });
 
     return (
       <Fragment>
         <h2 className={titleClassNames}>{title || defaultTitle}</h2>
         {subTitle && (
-          <h4 className="header-menu__location-sub-title">{subTitle}</h4>
+          <h4 className="fd-header-menu__location-sub-title">{subTitle}</h4>
         )}
       </Fragment>
     );
@@ -106,12 +106,12 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
         const key = `${label}__${index}`;
         const isSelected = path === currentlyViewing.path;
         const subOptionClassNames = classNames({
-          'header-menu__sub-option-link': true,
-          [`header-menu__sub-option-link-${label
+          'fd-header-menu__sub-option-link': true,
+          [`fd-header-menu__sub-option-link-${label
             .toLowerCase()
             .split(' ')
             .join('-')}`]: true,
-          'header-menu__sub-option-link-selected': isSelected,
+          'fd-header-menu__sub-option-link-selected': isSelected,
         });
 
         if (href) {
@@ -129,7 +129,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
                 setSelectedOption(null);
               }}
             >
-              <i className="material-icons header-menu__sub-option-icon">
+              <i className="material-icons fd-header-menu__sub-option-icon">
                 {icon}
               </i>
               {label}
@@ -155,7 +155,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
                 }
               }}
             >
-              <i className="material-icons header-menu__sub-option-icon">
+              <i className="material-icons fd-header-menu__sub-option-icon">
                 {icon}
               </i>
               {label}
@@ -167,7 +167,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
       });
 
   const renderMenuOptions = (): ReactElement => (
-    <div className="header-menu__menu-icon-container">
+    <div className="fd-header-menu__menu-icon-container">
       {Object.keys(menuOptions).map((option, index) => {
         const key = `${option}__${index}`;
         const { icon, subOptions, subTitle, indicator, isActive } = menuOptions[
@@ -175,15 +175,15 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
         ] as HeaderMenuOption;
         const menuOptionIconClassNames = classNames({
           'material-icons': true,
-          'header-menu__menu-icon': true,
-          [`header-menu__menu-icon-${option}`]: true,
-          'header-menu__menu-icon-selected':
+          'fd-header-menu__menu-icon': true,
+          [`fd-header-menu__menu-icon-${option}`]: true,
+          'fd-header-menu__menu-icon-selected':
             selectedOption === option || isActive,
         });
 
         return (
           <Fragment key={key}>
-            <div className="header-menu__icon-container">
+            <div className="fd-header-menu__icon-container">
               <i
                 className={menuOptionIconClassNames}
                 role="menuitem"
@@ -203,7 +203,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
               </i>
               {indicator && (
                 <div
-                  className="header-menu__icon-indicator"
+                  className="fd-header-menu__icon-indicator"
                   role="menuitem"
                   tabIndex={-1}
                   onClick={(): void => {
@@ -221,13 +221,16 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
                 </div>
               )}
               {subOptions && selectedOption === option && (
-                <div className="header-menu__sub-options" ref={subOptionsMenu}>
-                  <div className="header-menu__sub-options-header">
-                    <span className="header-menu__sub-options-title">
+                <div
+                  className="fd-header-menu__sub-options"
+                  ref={subOptionsMenu}
+                >
+                  <div className="fd-header-menu__sub-options-header">
+                    <span className="fd-header-menu__sub-options-title">
                       {option}
                     </span>
                     {subTitle && (
-                      <span className="header-menu__sub-options-sub-title">
+                      <span className="fd-header-menu__sub-options-sub-title">
                         {subTitle}
                       </span>
                     )}
@@ -243,14 +246,14 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
   );
 
   return (
-    <div className="header-menu">
-      <div className="header-menu__left">
-        <div className="header-menu__location-container">
+    <div className="fd-header-menu">
+      <div className="fd-header-menu__left">
+        <div className="fd-header-menu__location-container">
           {currentlyViewing && renderCurrentlyViewingHeader(currentlyViewing)}
         </div>
       </div>
 
-      <div className="header-menu__right">
+      <div className="fd-header-menu__right">
         {menuOptions && renderMenuOptions()}
       </div>
     </div>

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -33,17 +33,13 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
   const subOptionsMenu = useRef<HTMLDivElement>(null);
 
   const handleRemoveEventListener = (): void => {
-    document.removeEventListener(
-      'click',
-      (handleHeaderMenuOutsideClick as Function) as EventListener,
-      false
-    );
+    document.removeEventListener('click', handleHeaderMenuOutsideClick);
   };
 
-  const handleHeaderMenuOutsideClick = (event: SyntheticEvent): void => {
+  const handleHeaderMenuOutsideClick = (event: MouseEvent): void => {
     if (
       subOptionsMenu.current &&
-      !subOptionsMenu.current.contains(event.currentTarget)
+      !subOptionsMenu.current.contains(event.currentTarget as Node)
     ) {
       handleRemoveEventListener();
       setSelectedOption(null);
@@ -58,11 +54,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
 
     if (subOptions) {
       if (!selectedOption) {
-        document.addEventListener(
-          'click',
-          (handleHeaderMenuOutsideClick as Function) as EventListener,
-          false
-        );
+        document.addEventListener('click', handleHeaderMenuOutsideClick);
       }
 
       setSelectedOption(name);
@@ -81,12 +73,9 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
         title,
       });
     }
-
     if (subOptionsMenu) {
       handleRemoveEventListener();
     }
-
-    setSelectedOption(null);
   };
 
   // RENDER METHODS

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -1,6 +1,6 @@
 @import '../../../styles/main';
 
-.fd-side-navigation {
+.fd-side-navigation, .fd-side-navigation-dark {
   top: 0;
   left: 0;
   right: auto;
@@ -253,8 +253,11 @@
         color: $brand-color;
       }
     }
-    &-collapsed:hover > .fd-side-navigation__collapse-text {
-      color: transparent;
+    &-collapsed:hover {
+      > .fd-side-navigation__collapse-text,
+      > .fd-side-navigation-dark__collapse-text {
+        color: transparent;
+      }
     }
     &::before {
       @include gradientPseudoBorderTop($white, $gray-04);
@@ -280,4 +283,8 @@
       color: transparent;
     }
   }
+}
+
+.fd-side-navigation-dark {
+  @include side-navigation-dark;
 }

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/main';
+
 .side-navigation {
   top: 0;
   left: 0;
@@ -5,8 +7,8 @@
   display: flex;
   flex-direction: column;
   width: 230px;
-  border: 1px solid #d8dde6;
-  background-color: #fff;
+  border: 1px solid $gray-04;
+  background-color: $white;
   box-shadow: rgba(99, 115, 138, 0.2) 0px 5px 5px -3px,
     rgba(99, 115, 138, 0.14) 0px 8px 10px 1px,
     rgba(99, 115, 138, 0.12) 0px 3px 14px 2px;
@@ -49,10 +51,10 @@
   &__logo-back {
     position: relative;
     left: 0;
-    color: #63738a;
+    color: $cool-gray-11;
     transition: 0.3s ease-in-out;
     &-hidden {
-      color: rgba(0, 0, 0, 0);
+      color: transparent;
     }
     &-collapsed-away {
       left: -1rem;
@@ -83,7 +85,7 @@
   &__logo-text {
     width: 8.25rem;
     margin-left: 0.65rem;
-    color: #4a4a4a;
+    color: $gray-15;
     font-size: 1rem;
     text-decoration: none;
     text-overflow: ellipsis;
@@ -92,7 +94,7 @@
     visibility: visible;
     transition: color 0.1s ease-in-out;
     &.hidden-text {
-      color: rgba(0, 0, 0, 0);
+      color: transparent;
     }
   }
   &__menu {
@@ -106,7 +108,7 @@
     align-items: flex-start;
     padding: 0.5rem;
     &-selected {
-      background-color: #f8f8f8;
+      background-color: $gray-02;
     }
     &-collapsed {
       padding: 0.5rem;
@@ -123,21 +125,22 @@
     cursor: pointer;
     transition: color 0.1s ease-in-out;
     &-selected {
-      color: #0073d1;
+      color: $brand-color;
       cursor: default;
     }
     &-hidden {
-      color: rgba(0, 0, 0, 0);
+      color: transparent;
     }
   }
   &__option-icon {
     position: absolute;
     left: 1.25rem;
-    color: rgba(99, 115, 138, 0.8);
+    color: $cool-gray-11;
+    opacity: 0.8;
     font-size: 1rem;
     transition: 0.2s 0.1s ease-in-out;
     &-selected {
-      color: #0073d1;
+      color: $brand-color;
     }
     &-hidden {
       left: 1.75rem;
@@ -149,19 +152,19 @@
     min-width: 150px;
     margin-top: -0.5rem;
     padding-bottom: 0.25rem;
-    border: 1px solid #eee;
-    background-color: #fff;
+    border: 1px solid $gray-03;
+    background-color: $white;
     box-shadow: 2px 1px 3px rgba(0, 0, 0, 0.1);
   }
   &__option-hover-title {
     padding: 1rem;
-    border-bottom: 1px solid rgb(216, 221, 230);
+    border-bottom: 1px solid $gray-04;
     margin-bottom: 0.25rem;
     font-size: 1rem;
     font-weight: 500;
     text-transform: capitalize;
     &-selected {
-      color: #0073d1;
+      color: $brand-color;
     }
   }
   &__option-expansion-panel {
@@ -173,7 +176,7 @@
     text-transform: capitalize;
     cursor: pointer;
     &-selected {
-      background-color: #ebecee;
+      background-color: $gray-03;
     }
     &-hover {
       margin: 0 auto;
@@ -181,19 +184,19 @@
       border-radius: 0.125rem;
     }
     &:hover {
-      background-color: #ebecee;
+      background-color: $gray-03;
       > .side-navigation__sub-option-text {
-        color: #0073d1;
+        color: $brand-color;
       }
     }
   }
   &__sub-option-text {
-    color: #6c7b91;
+    color: $cool-gray-10;
     font-size: 1rem;
     font-weight: normal;
     transition: none !important;
     &.selected {
-      color: #000;
+      color: $black;
       font-weight: 500;
     }
   }
@@ -205,9 +208,9 @@
     padding: 1.5rem 0.5rem;
     cursor: pointer;
     &:hover {
-      color: #0073d1;
+      color: $brand-color;
       > * {
-        color: #0073d1;
+        color: $brand-color;
       }
     }
     &::before {
@@ -215,7 +218,7 @@
       position: absolute;
       top: 0;
       width: 11.25rem;
-      border-top: 1px solid rgb(216, 221, 230);
+      border-top: 1px solid $gray-04;
       transition: width 0.3s ease-in-out;
     }
     &.collapsed::before {
@@ -226,7 +229,7 @@
     position: absolute;
     left: 2rem;
     font-size: 1rem;
-    color: #63738a;
+    color: $cool-gray-11;
     transition: 0.2s 0.1s ease-in-out;
     &-collapsed {
       left: 2rem;
@@ -238,7 +241,7 @@
     margin-left: 3.375rem;
     transition: color 0.1s ease-in-out;
     &.hidden-text {
-      color: rgba(0, 0, 0, 0);
+      color: transparent;
     }
   }
 }

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -130,6 +130,7 @@
     transition: top 0.2s ease-in-out;
     &-collapsed {
       left: 2.6875rem;
+      transition: left 0.2s ease-in-out 0.1s;
     }
     &-transitioning {
       background: $brand-color;

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -130,7 +130,7 @@
     transition: top 0.2s ease-in-out;
     &-collapsed {
       left: 2.6875rem;
-      transition: left 0.2s ease-in-out 0.1s;
+      transition: top 0.2s ease-in-out, left 0.2s ease-in-out 0.1s;
     }
     &-transitioning {
       background: $brand-color;

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -179,9 +179,11 @@
     &-selected {
       color: $white;
       opacity: 1;
+      transition: left 0.2s 0.1s ease-in-out, color 0.1s ease-in-out 0.7s;
     }
     &-hidden {
       left: 1.75rem;
+      transition: left 0.2s 0.1s ease-in-out, color 0.1s ease-in-out 0.3s;
     }
   }
   &__option-hover-menu {
@@ -252,15 +254,8 @@
       }
     }
     &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      width: 11.25rem;
-      border-top: 1px solid $gray-04;
-      transition: width 0.3s ease-in-out;
-    }
-    &.collapsed::before {
-      width: 2.5rem;
+      @include gradientPseudoBorderTop($white, $gray-04);
+      width: 80%;
     }
   }
   &__collapse-icon {

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -35,6 +35,9 @@
     height: 88px;
     padding: 1.5rem;
     box-sizing: border-box;
+    &-image-only {
+      height: unset;
+    }
   }
   &__logo-link {
     flex: 1;
@@ -78,8 +81,11 @@
   }
   &__logo-image {
     height: 1.75rem;
-    &-larger {
-      height: 2.25rem;
+    &-large {
+      height: unset;
+      width: 100%;
+      min-width: 2rem;
+      max-width: 5rem;
     }
   }
   &__logo-text {

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -91,7 +91,7 @@
   &__logo-text {
     width: 8.25rem;
     margin-left: 0.65rem;
-    color: $gray-15;
+    color: $cool-gray-15;
     font-size: 1rem;
     text-decoration: none;
     text-overflow: ellipsis;
@@ -120,6 +120,37 @@
       padding: 0.5rem;
     }
   }
+  &__floating-icon-background {
+    position: absolute;
+    left: 2.1875rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    background-color: transparent;
+    transition: top 0.2s ease-in-out;
+    &-collapsed {
+      left: 2.6875rem;
+    }
+    &-transitioning {
+      background: $brand-color;
+    }
+  }
+  &__icon-background {
+    position: absolute;
+    left: 1.125rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    background: transparent;
+    border-radius: 50%;
+    transition: top 0.2s ease-in-out, background-color 0.01s;
+    &-collapsed {
+      left: 1.625rem;
+    }
+    &-selected {
+      background: $brand-color;
+      transition: background-color 0.01s ease 1s, left 0.2s ease-in-out 0.1s;
+    }
+  }
   &__option-title {
     position: relative;
     display: flex;
@@ -141,12 +172,13 @@
   &__option-icon {
     position: absolute;
     left: 1.25rem;
-    color: $cool-gray-11;
+    color: $brand-color;
     opacity: 0.8;
     font-size: 1rem;
     transition: 0.2s 0.1s ease-in-out;
     &-selected {
-      color: $brand-color;
+      color: $white;
+      opacity: 1;
     }
     &-hidden {
       left: 1.75rem;
@@ -191,7 +223,7 @@
     }
     &:hover {
       background-color: $gray-03;
-      > .side-navigation__sub-option-text {
+      > .fd-side-navigation__sub-option-text {
         color: $brand-color;
       }
     }

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -32,6 +32,7 @@
     width: 100%;
     height: 88px;
     padding: 1.5rem;
+    box-sizing: border-box;
   }
   &__logo-link {
     flex: 1;
@@ -74,10 +75,14 @@
     height: 1.75rem;
   }
   &__logo-text {
+    width: 8.25rem;
     margin-left: 0.65rem;
     color: #4a4a4a;
-    font-size: 1.5rem;
+    font-size: 1rem;
     text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
     visibility: visible;
     transition: color 0.1s ease-in-out;
     &.hidden-text {

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -222,6 +222,7 @@
       margin: 0 auto;
       padding: 0.5rem 1rem;
       border-radius: 0.125rem;
+      transition: padding 0.05s ease-in-out;
     }
     &:hover {
       background-color: $gray-03;

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -1,6 +1,6 @@
 @import '../../../styles/main';
 
-.side-navigation {
+.fd-side-navigation {
   top: 0;
   left: 0;
   right: auto;

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -127,10 +127,9 @@
     height: 1.25rem;
     border-radius: 50%;
     background-color: transparent;
-    transition: top 0.2s ease-in-out;
+    transition: top 0.2s ease-in-out, left 0.2s ease-in-out 0.1s;
     &-collapsed {
       left: 2.6875rem;
-      transition: top 0.2s ease-in-out, left 0.2s ease-in-out 0.1s;
     }
     &-transitioning {
       background: $brand-color;

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -18,7 +18,7 @@
   transition: width 0.3s ease-in-out;
   outline: none;
   z-index: 1200;
-  &.collapsed {
+  &-collapsed {
     width: 90px;
   }
   *:focus {
@@ -99,7 +99,7 @@
     overflow: hidden;
     visibility: visible;
     transition: color 0.1s ease-in-out;
-    &.hidden-text {
+    &-hidden {
       color: transparent;
     }
   }
@@ -235,7 +235,7 @@
     font-size: 1rem;
     font-weight: normal;
     transition: none !important;
-    &.selected {
+    &-selected {
       color: $black;
       font-weight: 500;
     }
@@ -252,6 +252,9 @@
       > * {
         color: $brand-color;
       }
+    }
+    &-collapsed:hover > .fd-side-navigation__collapse-text {
+      color: transparent;
     }
     &::before {
       @include gradientPseudoBorderTop($white, $gray-04);
@@ -273,7 +276,7 @@
     width: 100%;
     margin-left: 3.375rem;
     transition: color 0.1s ease-in-out;
-    &.hidden-text {
+    &-hidden {
       color: transparent;
     }
   }

--- a/src/components/Navigation/SideNavigation/SideNavigation.scss
+++ b/src/components/Navigation/SideNavigation/SideNavigation.scss
@@ -42,6 +42,9 @@
     text-decoration: none;
     outline: none;
     cursor: pointer;
+    &-image-only {
+      justify-content: flex-start;
+    }
   }
   &__logo-back {
     position: relative;
@@ -73,6 +76,9 @@
   }
   &__logo-image {
     height: 1.75rem;
+    &-larger {
+      height: 2.25rem;
+    }
   }
   &__logo-text {
     width: 8.25rem;

--- a/src/components/Navigation/SideNavigation/SideNavigation.stories.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { checkA11y } from '@storybook/addon-a11y';
+import React, { useState } from 'react';
+import { withA11Y } from '@storybook/addon-a11y';
 import { storiesOf } from '@storybook/react';
 
 import SideNavigation from './SideNavigation';
@@ -20,6 +20,8 @@ const sideNavigationMenuOptions = {
 const currentlyViewing = {
   path: '/user/my info',
   title: 'user',
+  backPath: '/',
+  backTitle: 'Home',
 };
 
 const defaultSelected = {
@@ -28,7 +30,7 @@ const defaultSelected = {
 };
 
 storiesOf('Navigation/Side Navigation', module)
-  .addDecorator(checkA11y)
+  .addDecorator(withA11Y)
   .add('Default', () => (
     <SideNavigation
       currentlyViewing={currentlyViewing}
@@ -44,15 +46,23 @@ storiesOf('Navigation/Side Navigation', module)
       defaultSelected={defaultSelected}
     />
   ))
-  .add('With logo', () => (
-    <SideNavigation
-      currentlyViewing={currentlyViewing}
-      menuOptions={sideNavigationMenuOptions}
-      defaultSelected={defaultSelected}
-      logoAssetPath="https://developmentalfx.org/wp-content/uploads/2018/05/dfx-1.png"
-      showBackButton
-    />
-  ))
+  .add('With logo', () => {
+    const [showBackButton, toggleOnGoBack] = useState(true);
+
+    return (
+      <SideNavigation
+        currentlyViewing={currentlyViewing}
+        menuOptions={sideNavigationMenuOptions}
+        defaultSelected={defaultSelected}
+        logoAssetPath="https://developmentalfx.org/wp-content/uploads/2018/05/dfx-1.png"
+        showBackButton={showBackButton}
+        onGoBack={(): void => {
+          toggleOnGoBack(false);
+          setTimeout(() => toggleOnGoBack(true), 1000);
+        }}
+      />
+    );
+  })
   .add('With logo and title', () => (
     <SideNavigation
       currentlyViewing={currentlyViewing}

--- a/src/components/Navigation/SideNavigation/SideNavigation.stories.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.stories.tsx
@@ -22,16 +22,18 @@ const currentlyViewing = {
   title: 'user',
 };
 
+const defaultSelected = {
+  option: 'user',
+  subOption: 'my info',
+};
+
 storiesOf('Navigation/Side Navigation', module)
   .addDecorator(checkA11y)
   .add('Default', () => (
     <SideNavigation
       currentlyViewing={currentlyViewing}
       menuOptions={sideNavigationMenuOptions}
-      defaultSelected={{
-        option: 'user',
-        subOption: 'my info',
-      }}
+      defaultSelected={defaultSelected}
     />
   ))
   .add('Collapsed by default', () => (
@@ -39,9 +41,24 @@ storiesOf('Navigation/Side Navigation', module)
       collapsed
       currentlyViewing={currentlyViewing}
       menuOptions={sideNavigationMenuOptions}
-      defaultSelected={{
-        option: 'user',
-        subOption: 'my info',
-      }}
+      defaultSelected={defaultSelected}
+    />
+  ))
+  .add('With logo', () => (
+    <SideNavigation
+      currentlyViewing={currentlyViewing}
+      menuOptions={sideNavigationMenuOptions}
+      defaultSelected={defaultSelected}
+      logoAssetPath="https://developmentalfx.org/wp-content/uploads/2018/05/dfx-1.png"
+      showBackButton
+    />
+  ))
+  .add('With logo and title', () => (
+    <SideNavigation
+      currentlyViewing={currentlyViewing}
+      menuOptions={sideNavigationMenuOptions}
+      defaultSelected={defaultSelected}
+      logoAssetPath="https://developmentalfx.org/wp-content/uploads/2018/05/dfx-1.png"
+      logoTitle="DevelopmentalFX"
     />
   ));

--- a/src/components/Navigation/SideNavigation/SideNavigation.stories.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.stories.tsx
@@ -71,4 +71,12 @@ storiesOf('Navigation/Side Navigation', module)
       logoAssetPath="https://developmentalfx.org/wp-content/uploads/2018/05/dfx-1.png"
       logoTitle="DevelopmentalFX"
     />
+  ))
+  .add('Dark theme', () => (
+    <SideNavigation
+      goDark
+      currentlyViewing={currentlyViewing}
+      menuOptions={sideNavigationMenuOptions}
+      defaultSelected={defaultSelected}
+    />
   ));

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -296,11 +296,6 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                     handleSelectOption(option);
                   }
                 }}
-                onKeyDown={(): void => {
-                  if (!isCollapsed && !isOptionSelected) {
-                    handleSelectOption(option);
-                  }
-                }}
               >
                 <i className={optionIconClassNames}>{optionObject.icon}</i>
                 {option}
@@ -355,7 +350,6 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
           aria-selected={isSelected}
           className={subOptionClassNames}
           onClick={(): void => handleSelectSubOption(subOption)}
-          onKeyDown={(): void => handleSelectSubOption(subOption)}
         >
           <div
             className={`side-navigation__sub-option-text ${
@@ -395,7 +389,12 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   return (
     <div className={`side-navigation ${isCollapsed ? 'collapsed' : ''}`}>
       {hasHeader && (
-        <div className="side-navigation__header">
+        <div
+          className={classnames({
+            'side-navigation__header': true,
+            'side-navigation__header-image-only': logoAssetPath && !logoTitle,
+          })}
+        >
           <div
             role="link"
             tabIndex={0}
@@ -405,11 +404,6 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                 logoAssetPath && !logoTitle,
             })}
             onClick={(): void => {
-              if (showBackButton) {
-                handleGoBack();
-              }
-            }}
-            onKeyDown={(): void => {
               if (showBackButton) {
                 handleGoBack();
               }
@@ -454,7 +448,6 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
           isCollapsed ? 'collapsed' : ''
         }`}
         onClick={handleToggleCollapse}
-        onKeyDown={handleToggleCollapse}
       >
         <i className={collapseIconClassNames}>arrow_back_ios</i>
         <span

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -110,31 +110,6 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   );
 
   useEffect(() => {
-    if (collapsed) {
-      const selectedSubOption = currentlyViewing
-        ? getPreSelection(Object.keys(menuOptions), currentlyViewing)
-        : defaultSelected.option;
-
-      setSelection({
-        option: undefined,
-        subOption: selectedSubOption,
-      });
-    } else {
-      const selectedOption = currentlyViewing
-        ? getPreSelection(Object.keys(menuOptions), currentlyViewing)
-        : defaultSelected.option;
-      const selectedSubOption = currentlyViewing
-        ? getPreSelection(getSubOptions(menuOptions), currentlyViewing)
-        : defaultSelected.subOption;
-
-      setSelection({
-        option: selectedOption,
-        subOption: selectedSubOption,
-      });
-    }
-  }, []);
-
-  useEffect(() => {
     const newOption = getPreSelection(
       Object.keys(menuOptions),
       currentlyViewing

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -103,6 +103,8 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
     logoTitle,
   } = props;
 
+  const [isTransitioning, toggleIsTransitioning] = useState(false);
+  const [iconBackgroundTop, setIconBackgroundTop] = useState('26px');
   const [isCollapsed, toggleCollapsed] = useState(collapsed);
   const [selection, setSelection] = useState<SideNavigationSelection>(
     getInitialSelection(props)
@@ -125,6 +127,23 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
       handleUpdateSelection(newOption, newSubOption);
     }
   }, [currentlyViewing]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      const { top } = document
+        .getElementsByClassName('fd-side-navigation__option-icon-selected')[0]
+        .getBoundingClientRect();
+
+      const iconTop = `${top - 2}px`;
+      setIconBackgroundTop(iconTop);
+    }, 500);
+  }, [selection]);
+
+  useEffect(() => {
+    if (isTransitioning) {
+      setTimeout(() => toggleIsTransitioning(false), 1250);
+    }
+  }, [isTransitioning]);
 
   // LOCAL STATE CHANGE/TOGGLE METHODS
   const handleUpdateSelection = (
@@ -169,7 +188,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
     }
   };
 
-  const handleSelectSubOption = (subOption: string): void => {
+  const getSubOptionParent = (subOption: string): string | undefined => {
     const subOptionParent = Object.keys(menuOptions).find(option => {
       const match = menuOptions[option].subOptions.find(
         sub => sub === subOption
@@ -181,6 +200,18 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
 
       return false;
     });
+
+    return subOptionParent;
+  };
+
+  const handleSelectSubOption = (subOption: string): void => {
+    const subOptionParent = getSubOptionParent(subOption);
+    const currentSelectedSubOptionParent =
+      selection.subOption && getSubOptionParent(selection.subOption);
+
+    if (subOptionParent !== currentSelectedSubOptionParent) {
+      toggleIsTransitioning(true);
+    }
 
     if (onNavigate && subOptionParent) {
       onNavigate({
@@ -297,6 +328,13 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                   }
                 }}
               >
+                <div
+                  className={classnames({
+                    'fd-side-navigation__icon-background': true,
+                    'fd-side-navigation__icon-background-collapsed': isCollapsed,
+                    'fd-side-navigation__icon-background-selected': isOptionSelected,
+                  })}
+                />
                 <i className={optionIconClassNames}>{optionObject.icon}</i>
                 {option}
               </div>
@@ -439,7 +477,17 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
         </div>
       )}
 
-      <div className="fd-side-navigation__menu">{renderMenuOptions()}</div>
+      <div className="fd-side-navigation__menu">
+        <div
+          className={classnames({
+            'fd-side-navigation__floating-icon-background': true,
+            'fd-side-navigation__floating-icon-background-collapsed': isCollapsed,
+            'fd-side-navigation__floating-icon-background-transitioning': isTransitioning,
+          })}
+          style={{ top: iconBackgroundTop }}
+        />
+        {renderMenuOptions()}
+      </div>
 
       <div
         role="switch"

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -389,9 +389,10 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
           onClick={(): void => handleSelectSubOption(subOption)}
         >
           <div
-            className={`fd-side-navigation__sub-option-text ${
-              isSelected ? 'selected' : ''
-            }`}
+            className={classnames({
+              'fd-side-navigation__sub-option-text': true,
+              'fd-side-navigation__sub-option-text-selected': isSelected,
+            })}
           >
             {subOption}
           </div>
@@ -425,7 +426,12 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   const hasHeader = logoAssetPath || logoTitle;
 
   return (
-    <nav className={`fd-side-navigation ${isCollapsed ? 'collapsed' : ''}`}>
+    <nav
+      className={classnames({
+        'fd-side-navigation': true,
+        'fd-side-navigation-collapsed': isCollapsed,
+      })}
+    >
       {hasHeader && (
         <div
           className={classnames({
@@ -464,9 +470,10 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                 )}
                 {logoTitle && (
                   <span
-                    className={`fd-side-navigation__logo-text ${
-                      isCollapsed ? 'hidden-text' : ''
-                    }`}
+                    className={classnames({
+                      'fd-side-navigation__logo-text': true,
+                      'fd-side-navigation__logo-text-hidden': isCollapsed,
+                    })}
                   >
                     {logoTitle}
                   </span>
@@ -493,16 +500,18 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
         role="switch"
         tabIndex={0}
         aria-checked={isCollapsed}
-        className={`fd-side-navigation__collapse-toggle ${
-          isCollapsed ? 'collapsed' : ''
-        }`}
+        className={classnames({
+          'fd-side-navigation__collapse-toggle': true,
+          'fd-side-navigation__collapse-toggle-collapsed': isCollapsed,
+        })}
         onClick={handleToggleCollapse}
       >
         <i className={collapseIconClassNames}>arrow_back_ios</i>
         <span
-          className={`fd-side-navigation__collapse-text ${
-            isCollapsed ? 'hidden-text' : ''
-          }`}
+          className={classnames({
+            'fd-side-navigation__collapse-text': true,
+            'fd-side-navigation__collapse-text-hidden': isCollapsed,
+          })}
         >
           {'Collapse'}
         </span>

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   FunctionComponent,
 } from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import {
   CurrentlyViewing,
@@ -213,21 +213,21 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
             subOption => subOption === selectedSubOption
           );
 
-          const optionMenuClassNames = classNames({
+          const optionMenuClassNames = classnames({
             'side-navigation__option-menu': true,
             [`side-navigation__option-menu-${option}`]: true,
             'side-navigation__option-menu-selected': isOptionSelected,
             'side-navigation__option-menu-collapsed': isCollapsed,
           });
 
-          const optionTitleClassNames = classNames({
+          const optionTitleClassNames = classnames({
             'side-navigation__option-title': true,
             [`side-navigation__option-title-${option}`]: true,
             'side-navigation__option-title-selected': isOptionSelected,
             'side-navigation__option-title-hidden': isCollapsed,
           });
 
-          const optionIconClassNames = classNames({
+          const optionIconClassNames = classnames({
             'material-icons': true,
             'side-navigation__option-icon': true,
             [`side-navigation__option-icon-${option}`]: true,
@@ -235,12 +235,12 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
             'side-navigation__option-icon-hidden': isCollapsed,
           });
 
-          const optionHoverTitleClassNames = classNames({
+          const optionHoverTitleClassNames = classnames({
             'side-navigation__option-hover-title': true,
             'side-navigation__option-hover-title-selected': isOptionSelected,
           });
 
-          const optionExpansionPanelClassNames = classNames({
+          const optionExpansionPanelClassNames = classnames({
             'side-navigation__option-expansion-panel': true,
             [`side-navigation__option-expansion-panel-${option}`]: true,
           });
@@ -308,7 +308,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
     return subOptions.map((subOption, subIndex) => {
       const key = `${subOption}__${subIndex}`;
       const isSelected = subOption === selectedSubOption;
-      const subOptionClassNames = classNames({
+      const subOptionClassNames = classnames({
         'side-navigation__sub-option': true,
         [`side-navigation__sub-option-${subOption}`]: true,
         'side-navigation__sub-option-selected': isSelected,
@@ -337,7 +337,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
     });
   };
 
-  const logoWrapperClassNames = classNames({
+  const logoWrapperClassNames = classnames({
     'side-navigation__logo-wrapper': true,
     'side-navigation__logo-wrapper-home': !showBackButton,
     'side-navigation__logo-wrapper-away': showBackButton,
@@ -345,20 +345,20 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
       isCollapsed && showBackButton,
   });
 
-  const backIconClassNames = classNames({
+  const backIconClassNames = classnames({
     'material-icons': true,
     'side-navigation__logo-back': true,
     'side-navigation__logo-back-hidden': !showBackButton,
     'side-navigation__logo-back-collapsed-away': isCollapsed && showBackButton,
   });
 
-  const collapseIconClassNames = classNames({
+  const collapseIconClassNames = classnames({
     'material-icons': true,
     'side-navigation__collapse-icon': true,
     'side-navigation__collapse-icon-collapsed': isCollapsed,
   });
 
-  const hasHeader = onGoBack || logoAssetPath || logoTitle;
+  const hasHeader = logoAssetPath || logoTitle;
 
   return (
     <div className={`side-navigation ${isCollapsed ? 'collapsed' : ''}`}>
@@ -367,7 +367,11 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
           <div
             role="link"
             tabIndex={0}
-            className="side-navigation__logo-link"
+            className={classnames({
+              'side-navigation__logo-link': true,
+              'side-navigation__logo-link-image-only':
+                logoAssetPath && !logoTitle,
+            })}
             onClick={(): void => {
               if (showBackButton) {
                 handleGoBack();
@@ -385,7 +389,10 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
               <div className={logoWrapperClassNames}>
                 {logoAssetPath && (
                   <img
-                    className="side-navigation__logo-image"
+                    className={classnames({
+                      'side-navigation__logo-image': true,
+                      'side-navigation__logo-image-large': !logoTitle,
+                    })}
                     alt={logoTitle}
                     src={logoAssetPath}
                   />

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -95,7 +95,6 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
     menuOptions,
     currentlyViewing,
     onGoBack,
-    defaultSelected,
     collapsed,
     onCollapse,
     showBackButton,

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -246,35 +246,35 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
           );
 
           const optionMenuClassNames = classnames({
-            'side-navigation__option-menu': true,
-            [`side-navigation__option-menu-${option}`]: true,
-            'side-navigation__option-menu-selected': isOptionSelected,
-            'side-navigation__option-menu-collapsed': isCollapsed,
+            'fd-side-navigation__option-menu': true,
+            [`fd-side-navigation__option-menu-${option}`]: true,
+            'fd-side-navigation__option-menu-selected': isOptionSelected,
+            'fd-side-navigation__option-menu-collapsed': isCollapsed,
           });
 
           const optionTitleClassNames = classnames({
-            'side-navigation__option-title': true,
-            [`side-navigation__option-title-${option}`]: true,
-            'side-navigation__option-title-selected': isOptionSelected,
-            'side-navigation__option-title-hidden': isCollapsed,
+            'fd-side-navigation__option-title': true,
+            [`fd-side-navigation__option-title-${option}`]: true,
+            'fd-side-navigation__option-title-selected': isOptionSelected,
+            'fd-side-navigation__option-title-hidden': isCollapsed,
           });
 
           const optionIconClassNames = classnames({
             'material-icons': true,
-            'side-navigation__option-icon': true,
-            [`side-navigation__option-icon-${option}`]: true,
-            'side-navigation__option-icon-selected': isOptionSelected,
-            'side-navigation__option-icon-hidden': isCollapsed,
+            'fd-side-navigation__option-icon': true,
+            [`fd-side-navigation__option-icon-${option}`]: true,
+            'fd-side-navigation__option-icon-selected': isOptionSelected,
+            'fd-side-navigation__option-icon-hidden': isCollapsed,
           });
 
           const optionHoverTitleClassNames = classnames({
-            'side-navigation__option-hover-title': true,
-            'side-navigation__option-hover-title-selected': isOptionSelected,
+            'fd-side-navigation__option-hover-title': true,
+            'fd-side-navigation__option-hover-title-selected': isOptionSelected,
           });
 
           const optionExpansionPanelClassNames = classnames({
-            'side-navigation__option-expansion-panel': true,
-            [`side-navigation__option-expansion-panel-${option}`]: true,
+            'fd-side-navigation__option-expansion-panel': true,
+            [`fd-side-navigation__option-expansion-panel-${option}`]: true,
           });
 
           return (
@@ -302,7 +302,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
               </div>
               {isCollapsed && selection.option === option && (
                 <div
-                  className="side-navigation__option-hover-menu"
+                  className="fd-side-navigation__option-hover-menu"
                   onMouseLeave={(): void => {
                     if (isCollapsed) {
                       handleSelectOption(null);
@@ -335,10 +335,10 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
       const key = `${subOption}__${subIndex}`;
       const isSelected = subOption === selection.subOption;
       const subOptionClassNames = classnames({
-        'side-navigation__sub-option': true,
-        [`side-navigation__sub-option-${subOption}`]: true,
-        'side-navigation__sub-option-selected': isSelected,
-        'side-navigation__sub-option-hover': isCollapsed,
+        'fd-side-navigation__sub-option': true,
+        [`fd-side-navigation__sub-option-${subOption}`]: true,
+        'fd-side-navigation__sub-option-selected': isSelected,
+        'fd-side-navigation__sub-option-hover': isCollapsed,
       });
 
       return (
@@ -351,7 +351,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
           onClick={(): void => handleSelectSubOption(subOption)}
         >
           <div
-            className={`side-navigation__sub-option-text ${
+            className={`fd-side-navigation__sub-option-text ${
               isSelected ? 'selected' : ''
             }`}
           >
@@ -363,43 +363,45 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   };
 
   const logoWrapperClassNames = classnames({
-    'side-navigation__logo-wrapper': true,
-    'side-navigation__logo-wrapper-home': !showBackButton,
-    'side-navigation__logo-wrapper-away': showBackButton,
-    'side-navigation__logo-wrapper-collapsed-away':
+    'fd-side-navigation__logo-wrapper': true,
+    'fd-side-navigation__logo-wrapper-home': !showBackButton,
+    'fd-side-navigation__logo-wrapper-away': showBackButton,
+    'fd-side-navigation__logo-wrapper-collapsed-away':
       isCollapsed && showBackButton,
   });
 
   const backIconClassNames = classnames({
     'material-icons': true,
-    'side-navigation__logo-back': true,
-    'side-navigation__logo-back-hidden': !showBackButton,
-    'side-navigation__logo-back-collapsed-away': isCollapsed && showBackButton,
+    'fd-side-navigation__logo-back': true,
+    'fd-side-navigation__logo-back-hidden': !showBackButton,
+    'fd-side-navigation__logo-back-collapsed-away':
+      isCollapsed && showBackButton,
   });
 
   const collapseIconClassNames = classnames({
     'material-icons': true,
-    'side-navigation__collapse-icon': true,
-    'side-navigation__collapse-icon-collapsed': isCollapsed,
+    'fd-side-navigation__collapse-icon': true,
+    'fd-side-navigation__collapse-icon-collapsed': isCollapsed,
   });
 
   const hasHeader = logoAssetPath || logoTitle;
 
   return (
-    <div className={`side-navigation ${isCollapsed ? 'collapsed' : ''}`}>
+    <nav className={`fd-side-navigation ${isCollapsed ? 'collapsed' : ''}`}>
       {hasHeader && (
         <div
           className={classnames({
-            'side-navigation__header': true,
-            'side-navigation__header-image-only': logoAssetPath && !logoTitle,
+            'fd-side-navigation__header': true,
+            'fd-side-navigation__header-image-only':
+              logoAssetPath && !logoTitle,
           })}
         >
           <div
             role="link"
             tabIndex={0}
             className={classnames({
-              'side-navigation__logo-link': true,
-              'side-navigation__logo-link-image-only':
+              'fd-side-navigation__logo-link': true,
+              'fd-side-navigation__logo-link-image-only':
                 logoAssetPath && !logoTitle,
             })}
             onClick={(): void => {
@@ -415,8 +417,8 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                 {logoAssetPath && (
                   <img
                     className={classnames({
-                      'side-navigation__logo-image': true,
-                      'side-navigation__logo-image-large': !logoTitle,
+                      'fd-side-navigation__logo-image': true,
+                      'fd-side-navigation__logo-image-large': !logoTitle,
                     })}
                     alt={logoTitle}
                     src={logoAssetPath}
@@ -424,7 +426,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                 )}
                 {logoTitle && (
                   <span
-                    className={`side-navigation__logo-text ${
+                    className={`fd-side-navigation__logo-text ${
                       isCollapsed ? 'hidden-text' : ''
                     }`}
                   >
@@ -437,27 +439,27 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
         </div>
       )}
 
-      <div className="side-navigation__menu">{renderMenuOptions()}</div>
+      <div className="fd-side-navigation__menu">{renderMenuOptions()}</div>
 
       <div
         role="switch"
         tabIndex={0}
         aria-checked={isCollapsed}
-        className={`side-navigation__collapse-toggle ${
+        className={`fd-side-navigation__collapse-toggle ${
           isCollapsed ? 'collapsed' : ''
         }`}
         onClick={handleToggleCollapse}
       >
         <i className={collapseIconClassNames}>arrow_back_ios</i>
         <span
-          className={`side-navigation__collapse-text ${
+          className={`fd-side-navigation__collapse-text ${
             isCollapsed ? 'hidden-text' : ''
           }`}
         >
           {'Collapse'}
         </span>
       </div>
-    </div>
+    </nav>
   );
 };
 

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -29,6 +29,7 @@ type SideNavigationProps = {
   onNavigate?: (currentlyViewing: CurrentlyViewing) => void;
   logoAssetPath?: string;
   logoTitle?: string;
+  goDark?: boolean;
 };
 
 type SideNavigationSelection = {
@@ -88,6 +89,9 @@ const getInitialSelection = (
   }
 };
 
+const getBaseClassName = (goDark: boolean | undefined): string =>
+  goDark ? 'fd-side-navigation-dark' : 'fd-side-navigation';
+
 const SideNavigation: FunctionComponent<SideNavigationProps> = (
   props: SideNavigationProps
 ) => {
@@ -101,8 +105,10 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
     onNavigate,
     logoAssetPath,
     logoTitle,
+    goDark,
   } = props;
 
+  const [baseClassName] = useState(getBaseClassName(goDark));
   const [isTransitioning, toggleIsTransitioning] = useState(false);
   const [iconBackgroundTop, setIconBackgroundTop] = useState('26px');
   const [isCollapsed, toggleCollapsed] = useState(collapsed);
@@ -131,7 +137,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   useEffect(() => {
     setTimeout(() => {
       const { top } = document
-        .getElementsByClassName('fd-side-navigation__option-icon-selected')[0]
+        .getElementsByClassName(`${baseClassName}__option-icon-selected`)[0]
         .getBoundingClientRect();
 
       const iconTop = `${top - 2}px`;
@@ -277,35 +283,35 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
           );
 
           const optionMenuClassNames = classnames({
-            'fd-side-navigation__option-menu': true,
-            [`fd-side-navigation__option-menu-${option}`]: true,
-            'fd-side-navigation__option-menu-selected': isOptionSelected,
-            'fd-side-navigation__option-menu-collapsed': isCollapsed,
+            [`${baseClassName}__option-menu`]: true,
+            [`${baseClassName}__option-menu-${option}`]: true,
+            [`${baseClassName}__option-menu-selected`]: isOptionSelected,
+            [`${baseClassName}__option-menu-collapsed`]: isCollapsed,
           });
 
           const optionTitleClassNames = classnames({
-            'fd-side-navigation__option-title': true,
-            [`fd-side-navigation__option-title-${option}`]: true,
-            'fd-side-navigation__option-title-selected': isOptionSelected,
-            'fd-side-navigation__option-title-hidden': isCollapsed,
+            [`${baseClassName}__option-title`]: true,
+            [`${baseClassName}__option-title-${option}`]: true,
+            [`${baseClassName}__option-title-selected`]: isOptionSelected,
+            [`${baseClassName}__option-title-hidden`]: isCollapsed,
           });
 
           const optionIconClassNames = classnames({
             'material-icons': true,
-            'fd-side-navigation__option-icon': true,
-            [`fd-side-navigation__option-icon-${option}`]: true,
-            'fd-side-navigation__option-icon-selected': isOptionSelected,
-            'fd-side-navigation__option-icon-hidden': isCollapsed,
+            [`${baseClassName}__option-icon`]: true,
+            [`${baseClassName}__option-icon-${option}`]: true,
+            [`${baseClassName}__option-icon-selected`]: isOptionSelected,
+            [`${baseClassName}__option-icon-hidden`]: isCollapsed,
           });
 
           const optionHoverTitleClassNames = classnames({
-            'fd-side-navigation__option-hover-title': true,
-            'fd-side-navigation__option-hover-title-selected': isOptionSelected,
+            [`${baseClassName}__option-hover-title`]: true,
+            [`${baseClassName}__option-hover-title-selected`]: isOptionSelected,
           });
 
           const optionExpansionPanelClassNames = classnames({
-            'fd-side-navigation__option-expansion-panel': true,
-            [`fd-side-navigation__option-expansion-panel-${option}`]: true,
+            [`${baseClassName}__option-expansion-panel`]: true,
+            [`${baseClassName}__option-expansion-panel-${option}`]: true,
           });
 
           return (
@@ -330,9 +336,9 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
               >
                 <div
                   className={classnames({
-                    'fd-side-navigation__icon-background': true,
-                    'fd-side-navigation__icon-background-collapsed': isCollapsed,
-                    'fd-side-navigation__icon-background-selected': isOptionSelected,
+                    [`${baseClassName}__icon-background`]: true,
+                    [`${baseClassName}__icon-background-collapsed`]: isCollapsed,
+                    [`${baseClassName}__icon-background-selected`]: isOptionSelected,
                   })}
                 />
                 <i className={optionIconClassNames}>{optionObject.icon}</i>
@@ -340,7 +346,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
               </div>
               {isCollapsed && selection.option === option && (
                 <div
-                  className="fd-side-navigation__option-hover-menu"
+                  className={`${baseClassName}__option-hover-menu`}
                   onMouseLeave={(): void => {
                     if (isCollapsed) {
                       handleSelectOption(null);
@@ -373,10 +379,10 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
       const key = `${subOption}__${subIndex}`;
       const isSelected = subOption === selection.subOption;
       const subOptionClassNames = classnames({
-        'fd-side-navigation__sub-option': true,
-        [`fd-side-navigation__sub-option-${subOption}`]: true,
-        'fd-side-navigation__sub-option-selected': isSelected,
-        'fd-side-navigation__sub-option-hover': isCollapsed,
+        [`${baseClassName}__sub-option`]: true,
+        [`${baseClassName}__sub-option-${subOption}`]: true,
+        [`${baseClassName}__sub-option-selected`]: isSelected,
+        [`${baseClassName}__sub-option-hover`]: isCollapsed,
       });
 
       return (
@@ -390,8 +396,8 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
         >
           <div
             className={classnames({
-              'fd-side-navigation__sub-option-text': true,
-              'fd-side-navigation__sub-option-text-selected': isSelected,
+              [`${baseClassName}__sub-option-text`]: true,
+              [`${baseClassName}__sub-option-text-selected`]: isSelected,
             })}
           >
             {subOption}
@@ -402,25 +408,25 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   };
 
   const logoWrapperClassNames = classnames({
-    'fd-side-navigation__logo-wrapper': true,
-    'fd-side-navigation__logo-wrapper-home': !showBackButton,
-    'fd-side-navigation__logo-wrapper-away': showBackButton,
-    'fd-side-navigation__logo-wrapper-collapsed-away':
+    [`${baseClassName}__logo-wrapper`]: true,
+    [`${baseClassName}__logo-wrapper-home`]: !showBackButton,
+    [`${baseClassName}__logo-wrapper-away`]: showBackButton,
+    [`${baseClassName}__logo-wrapper-collapsed-away`]:
       isCollapsed && showBackButton,
   });
 
   const backIconClassNames = classnames({
     'material-icons': true,
-    'fd-side-navigation__logo-back': true,
-    'fd-side-navigation__logo-back-hidden': !showBackButton,
-    'fd-side-navigation__logo-back-collapsed-away':
+    [`${baseClassName}__logo-back`]: true,
+    [`${baseClassName}__logo-back-hidden`]: !showBackButton,
+    [`${baseClassName}__logo-back-collapsed-away`]:
       isCollapsed && showBackButton,
   });
 
   const collapseIconClassNames = classnames({
     'material-icons': true,
-    'fd-side-navigation__collapse-icon': true,
-    'fd-side-navigation__collapse-icon-collapsed': isCollapsed,
+    [`${baseClassName}__collapse-icon`]: true,
+    [`${baseClassName}__collapse-icon-collapsed`]: isCollapsed,
   });
 
   const hasHeader = logoAssetPath || logoTitle;
@@ -428,15 +434,15 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   return (
     <nav
       className={classnames({
-        'fd-side-navigation': true,
-        'fd-side-navigation-collapsed': isCollapsed,
+        [`${baseClassName}`]: true,
+        [`${baseClassName}-collapsed`]: isCollapsed,
       })}
     >
       {hasHeader && (
         <div
           className={classnames({
-            'fd-side-navigation__header': true,
-            'fd-side-navigation__header-image-only':
+            [`${baseClassName}__header`]: true,
+            [`${baseClassName}__header-image-only`]:
               logoAssetPath && !logoTitle,
           })}
         >
@@ -444,8 +450,8 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
             role="link"
             tabIndex={0}
             className={classnames({
-              'fd-side-navigation__logo-link': true,
-              'fd-side-navigation__logo-link-image-only':
+              [`${baseClassName}__logo-link`]: true,
+              [`${baseClassName}__logo-link-image-only`]:
                 logoAssetPath && !logoTitle,
             })}
             onClick={(): void => {
@@ -461,8 +467,8 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                 {logoAssetPath && (
                   <img
                     className={classnames({
-                      'fd-side-navigation__logo-image': true,
-                      'fd-side-navigation__logo-image-large': !logoTitle,
+                      [`${baseClassName}__logo-image`]: true,
+                      [`${baseClassName}__logo-image-large`]: !logoTitle,
                     })}
                     alt={logoTitle}
                     src={logoAssetPath}
@@ -471,8 +477,8 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
                 {logoTitle && (
                   <span
                     className={classnames({
-                      'fd-side-navigation__logo-text': true,
-                      'fd-side-navigation__logo-text-hidden': isCollapsed,
+                      [`${baseClassName}__logo-text`]: true,
+                      [`${baseClassName}__logo-text-hidden`]: isCollapsed,
                     })}
                   >
                     {logoTitle}
@@ -484,12 +490,12 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
         </div>
       )}
 
-      <div className="fd-side-navigation__menu">
+      <div className={`${baseClassName}__menu`}>
         <div
           className={classnames({
-            'fd-side-navigation__floating-icon-background': true,
-            'fd-side-navigation__floating-icon-background-collapsed': isCollapsed,
-            'fd-side-navigation__floating-icon-background-transitioning': isTransitioning,
+            [`${baseClassName}__floating-icon-background`]: true,
+            [`${baseClassName}__floating-icon-background-collapsed`]: isCollapsed,
+            [`${baseClassName}__floating-icon-background-transitioning`]: isTransitioning,
           })}
           style={{ top: iconBackgroundTop }}
         />
@@ -501,16 +507,16 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
         tabIndex={0}
         aria-checked={isCollapsed}
         className={classnames({
-          'fd-side-navigation__collapse-toggle': true,
-          'fd-side-navigation__collapse-toggle-collapsed': isCollapsed,
+          [`${baseClassName}__collapse-toggle`]: true,
+          [`${baseClassName}__collapse-toggle-collapsed`]: isCollapsed,
         })}
         onClick={handleToggleCollapse}
       >
         <i className={collapseIconClassNames}>arrow_back_ios</i>
         <span
           className={classnames({
-            'fd-side-navigation__collapse-text': true,
-            'fd-side-navigation__collapse-text-hidden': isCollapsed,
+            [`${baseClassName}__collapse-text`]: true,
+            [`${baseClassName}__collapse-text-hidden`]: isCollapsed,
           })}
         >
           {'Collapse'}
@@ -528,6 +534,7 @@ SideNavigation.defaultProps = {
   onNavigate: undefined,
   logoAssetPath: undefined,
   logoTitle: undefined,
+  goDark: false,
 };
 
 export default SideNavigation;

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -315,7 +315,6 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
               )}
               <ExpansionPanel
                 className={optionExpansionPanelClassNames}
-                type="hidden"
                 expanded={
                   isCollapsed
                     ? false

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -387,7 +387,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = ({
                   <img
                     className="side-navigation__logo-image"
                     alt={logoTitle}
-                    src={`${process.env.PUBLIC_URL}${logoAssetPath}`}
+                    src={logoAssetPath}
                   />
                 )}
                 {logoTitle && (

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -46,12 +46,12 @@
     display: flex;
     flex-direction: column;
     min-width: 16.75rem;
-    height: 0;
+    max-height: 0;
     border: 0px solid transparent;
     box-sizing: border-box;
     background-color: $white;
     // Closing transitions
-    transition: height 0.2s ease-in-out, border 0.01s ease-in-out 0.2s;
+    transition: max-height 0.2s ease-in-out, border 0.01s ease-in-out 0.2s;
     > * {
       min-height: 0;
       max-height: 0;
@@ -59,14 +59,14 @@
       visibility: hidden;
     }
     &-open {
-      height: 12.5rem;
+      max-height: 12.5rem;
       padding: 0;
       border: 1px solid $gray-09;
       border-top: none;
       border-radius: 0 0 0.25rem 0.25rem;
       overflow: auto;
       // Opening transitions
-      transition: height 0.2s ease-in-out;
+      transition: max-height 0.2s ease-in-out;
       > * {
         min-height: 1.375rem;
         max-height: 1.375rem;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -38,6 +38,29 @@ $gray-20: #0C0C0C;
 $gray-21: #070707;
 $white: #fff;
 
+// COOL GRAYS
+$cool-gray-01: #B3D1F9;
+$cool-gray-02: #AECAF2;
+$cool-gray-03: #A5C0E5;
+$cool-gray-04: #9CB5D8;
+$cool-gray-05: #92AACC;
+$cool-gray-06: #89A0BF;
+$cool-gray-07: #8095B2;
+$cool-gray-08: #778AA5;
+$cool-gray-09: #6E8099;
+$cool-gray-10: #64758C;
+$cool-gray-11: #5B6A7F;
+$cool-gray-12: #526072;
+$cool-gray-13: #495566;
+$cool-gray-14: #404A59;
+$cool-gray-15: #37404C;
+$cool-gray-16: #2D353F;
+$cool-gray-17: #242A33;
+$cool-gray-18: #1B2026;
+$cool-gray-19: #121519;
+$cool-gray-20: #090A0C;
+$cool-gray-21: #050607;
+
 // REDS
 $destructive: #E52810;
 $destructive-hover: #D1250F;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -6,7 +6,7 @@
 }
 
 body {
-  color: $gray-16;
+  color: $cool-gray-19;
   font-size: 1rem;
   .fd-label {
     margin-bottom: 0.25rem;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -104,3 +104,92 @@
     @return black;
   }
 }
+
+@mixin side-navigation-dark {
+  border: 1px solid $cool-gray-17;
+  background-color: $cool-gray-11;
+  &__logo-back {
+    color: $cool-gray-17;
+  }
+  &__logo-text {
+    color: $cool-gray-17;
+    &-hidden {
+      color: transparent;
+    }
+  }
+  &__option-menu {
+    &-selected {
+      background-color: $cool-gray-14;
+    }
+  }
+  &__floating-icon-background {
+    &-transitioning {
+      background: $white;
+    }
+  }
+  &__icon-background {
+    &-selected {
+      background: $white;
+    }
+  }
+  &__option-title {
+    color: $white;
+    &-selected {
+      color: $white;
+    }
+    &-hidden {
+      color: transparent;
+    }
+  }
+  &__option-icon {
+    color: $white;
+    &-selected {
+      color: $brand-color;
+    }
+  }
+  &__option-hover-menu {
+    border: 1px solid $cool-gray-17;
+    background-color: $cool-gray-11;
+  }
+  &__option-hover-title {
+    border-bottom: 1px solid $cool-gray-17;
+    color: $white;
+  }
+  &__sub-option {
+    &-selected {
+      background-color: $cool-gray-17;
+    }
+    &:hover {
+      background-color: $cool-gray-17;
+      > .fd-side-navigation__sub-option-text {
+        color: $brand-white;
+      }
+    }
+  }
+  &__sub-option-text {
+    color: $brand-xx-light;
+    &.selected {
+      color: $brand-white;
+    }
+  }
+  &__collapse-toggle {
+    color: $white;
+    &:hover {
+      color: $brand-xx-light;
+      > * {
+        color: $brand-xx-light;
+      }
+    }
+    &::before {
+      @include gradientPseudoBorderTop($cool-gray-11, $cool-gray-17);
+    }
+  }
+  &__collapse-icon {
+    color: $cool-gray-17;
+  }
+  &-collapse-text {
+    &-hidden {
+      color: transparent;
+    }
+  }
+}

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -105,6 +105,69 @@
   }
 }
 
+@mixin header-menu-dark {
+  border: 1px solid $cool-gray-17;
+  background-color: $cool-gray-11;
+  color: $white;
+  &__location-sub-title {
+    color: $brand-xx-light;
+  }
+  &__menu-icon {
+    color: $white;
+    &:hover,
+    &-selected {
+      color: $brand-color;
+      + .fd-header-menu-dark__menu-icon-background {
+        background-color: $white;
+      }
+    }
+  }
+  &__icon-indicator {
+    background: #ff4d4a;
+    border: 1px solid $white;
+  }
+  &__sub-options {
+    border: 0px solid transparent;
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+    background-color: $cool-gray-14;
+    &-shown {
+      border: 1px solid $cool-gray-17;
+      box-shadow: 0 3px 14px 2px rgba(99, 115, 138, 0.12),
+        0 8px 10px 1px rgba(99, 115, 138, 0.14),
+        0 5px 5px 0 rgba(99, 115, 138, 0.2);
+    }
+  }
+  &__sub-options-header {
+    border-bottom: 1px solid $gray-04;
+  }
+  &__sub-options-sub-title {
+    color: $brand-xx-light;
+  }
+  &__sub-option-icon {
+    color: $white;
+    &-selected {
+      color: $brand-color;
+    }
+  }
+  &__sub-option-icon-background {
+    background-color: $cool-gray-14;
+    &-selected {
+      background-color: $white;
+    }
+  }
+  &__sub-option-link {
+    &:hover,
+    &-selected {
+      color: $brand-white;
+      background-color: $cool-gray-17;
+    }
+    &:hover > .fd-header-menu-dark__sub-option-icon {
+      color: $white;
+      opacity: 1;
+    }
+  }
+}
+
 @mixin side-navigation-dark {
   border: 1px solid $cool-gray-17;
   background-color: $cool-gray-11;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -19,6 +19,30 @@
   box-sizing: border-box;
 }
 
+@mixin gradientPseudoBorder($color-1, $color-2) {
+  content: '';
+  position: absolute;
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(
+    90deg,
+    $color-1 0%,
+    $color-2 25%,
+    $color-2 75%,
+    $color-1 100%
+  );
+}
+
+@mixin gradientPseudoBorderBottom($color-1: $gray-04, $color-2: $gray-07) {
+  @include gradientPseudoBorder($color-1, $color-2);
+  bottom: 0;
+}
+
+@mixin gradientPseudoBorderTop($color-1: $gray-04, $color-2: $gray-07) {
+  @include gradientPseudoBorder($color-1, $color-2);
+  top: 0;
+}
+
 // Check-mark animation influenced by and tweaked from
 // https://codepen.io/scottloway/pen/zqoLyQ
 @mixin check-mark-animation(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "src"
   ],
   "exclude": [
-    "nod_modules",
+    "node_modules",
     "dist",
     "src/**/*.stories.tsx"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "baseUrl": "src",
     "outDir": "./dist/",
     "sourceMap": true,
+    "declaration": true,
     "noImplicitAny": true,
     "strict": true,
     "module": "commonjs",
@@ -20,13 +21,14 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react",
-    "declaration": true
+    "jsx": "react"
   },
   "include": [
     "src"
   ],
   "exclude": [
+    "nod_modules",
+    "dist",
     "src/**/*.stories.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "react",
+    "declaration": true
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": "src",
     "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   mode: 'production',
   entry: './src/index.ts',
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
@@ -40,9 +40,6 @@ module.exports = {
         test: /\.tsx?$/,
         loader: 'awesome-typescript-loader',
         exclude: /node_modules/,
-        query: {
-          declaration: false,
-        },
       },
       {
         enforce: 'pre',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        loader: 'awesome-typescript-loader',
+        loader: 'ts-loader',
         exclude: /node_modules/,
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4140,7 +4140,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.2.5, debug@^3.2.6:
+debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4175,11 +4175,6 @@ deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4264,11 +4259,6 @@ detect-indent@^4.0.0:
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -5390,13 +5380,6 @@ fs-extra@^8.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-minipass@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.0.0.tgz#a6415edab02fae4b9e9230bc87ee2e4472003cd1"
@@ -5976,7 +5959,7 @@ husky@^3.1.0:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5999,13 +5982,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -6115,7 +6091,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7752,27 +7728,12 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -7876,15 +7837,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -8001,22 +7953,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.44:
   version "1.1.44"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.44.tgz#cd66438a6eb875e3eb012b6a12e48d9f4326ffd7"
@@ -8053,14 +7989,6 @@ node-sass@^4.13.0:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -8099,26 +8027,6 @@ normalize-url@1.9.1:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
-  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -8126,7 +8034,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8360,7 +8268,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4:
+osenv@0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -9134,16 +9042,6 @@ raw-loader@^2.0.0:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-clientside-effect@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -9791,7 +9689,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -10591,11 +10489,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 style-loader@^0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
@@ -10696,19 +10589,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 telejson@^3.0.2:
   version "3.3.0"
@@ -11630,7 +11510,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,7 +921,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.7.tgz#194769ca8d6d7790ec23605af9ee3e42a0aa79cf"
   integrity sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==
@@ -969,7 +969,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
+"@emotion/cache@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.27.tgz#7895db204e2c1a991ae33d51262a3a44f6737303"
   integrity sha512-Zp8BEpbMunFsTcqAK4D7YTm3MvCp1SekflSLJH8lze2fCcSZ/yMkXHo8kb3t1/1Tdd3hAqf3Fb7z9VZ+FMiC9w==
@@ -979,7 +979,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.14", "@emotion/core@^10.0.9":
+"@emotion/core@^10.0.14":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.27.tgz#7c3f78be681ab2273f3bf11ca3e2edc4a9dd1fdc"
   integrity sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==
@@ -991,7 +991,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
+"@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -1070,11 +1070,6 @@
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
-
-"@icons/material@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
-  integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
@@ -1290,30 +1285,6 @@
     react "^16.8.3"
     react-inspector "^3.0.2"
     uuid "^3.3.2"
-
-"@storybook/addon-knobs@^5.2.8":
-  version "5.2.8"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-5.2.8.tgz#e0d03823969921a0da57a329376d03066dd749ee"
-  integrity sha512-5SAMJj+0pbhCiyNkKjkUxEbM9L/wrOE4HTvM7gvm902fULuKZklb3wV8iiUNRfIPCs6VhmmIhPzXICGjhW5xIg==
-  dependencies:
-    "@storybook/addons" "5.2.8"
-    "@storybook/api" "5.2.8"
-    "@storybook/client-api" "5.2.8"
-    "@storybook/components" "5.2.8"
-    "@storybook/core-events" "5.2.8"
-    "@storybook/theming" "5.2.8"
-    "@types/react-color" "^3.0.1"
-    copy-to-clipboard "^3.0.8"
-    core-js "^3.0.1"
-    escape-html "^1.0.3"
-    fast-deep-equal "^2.0.1"
-    global "^4.3.2"
-    lodash "^4.17.15"
-    prop-types "^15.7.2"
-    qs "^6.6.0"
-    react-color "^2.17.0"
-    react-lifecycles-compat "^3.0.4"
-    react-select "^3.0.0"
 
 "@storybook/addon-links@^5.2.8":
   version "5.2.8"
@@ -1863,13 +1834,6 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-color@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-color/-/react-color-3.0.1.tgz#5433e2f503ea0e0831cbc6fd0c20f8157d93add0"
-  integrity sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-syntax-highlighter@10.1.0":
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.1.0.tgz#9c534e29bbe05dba9beae1234f3ae944836685d4"
@@ -1905,9 +1869,9 @@
     "@storybook/react" "^5.2.0"
 
 "@types/webpack-env@^1.13.7", "@types/webpack-env@^1.14.0":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.14.1.tgz#0d8a53f308f017c53a5ddc3d07f4d6fa76b790d7"
-  integrity sha512-0Ki9jAAhKDSuLDXOIMADg54Hu60SuBTEsWaJGGy5cV+SSUQ63J2a+RrYYGrErzz39fXzTibhKrAQJAb8M7PNcA==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.0.tgz#bd9956d5044b1fb43e869a9ba9148862ff98d9fd"
+  integrity sha512-TfcyNecCz8Z9/s90gBOBniyzZrTru8u2Vp0VZODq4KEBaQu8bfXvu7o/KUOecMpzjbFPUA7aqgSq628Iue5BQg==
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -1922,39 +1886,39 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^2.12.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.13.0.tgz#57e933fe16a2fc66dbac059af0d6d85d921d748e"
-  integrity sha512-QoiANo0MMGNa8ej/yX3BrW5dZj5d8HYcKiM2fyYUlezECqn8Xc7T/e4EUdiGinn8jhBrn+9X47E9TWaaup3u1g==
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.15.0.tgz#5442c30b687ffd576ff74cfea46a6d7bfb0ee893"
+  integrity sha512-XRJFznI5v4K1WvIrWmjFjBAdQWaUTz4xJEdqR7+wAFsv6Q9dP3mOlE6BMNT3pdlp9eF1+bC5m5LZTmLMqffCVw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.13.0"
+    "@typescript-eslint/experimental-utils" "2.15.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.13.0.tgz#958614faa6f77599ee2b241740e0ea402482533d"
-  integrity sha512-+Hss3clwa6aNiC8ZjA45wEm4FutDV5HsVXPl/rDug1THq6gEtOYRGLqS3JlTk7mSnL5TbJz0LpEbzbPnKvY6sw==
+"@typescript-eslint/experimental-utils@2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.15.0.tgz#41e35313bfaef91650ddb5380846d1c78a780070"
+  integrity sha512-Qkxu5zndY5hqlcQkmA88gfLvqQulMpX/TN91XC7OuXsRf4XG5xLGie0sbpX97o/oeccjeZYRMipIsjKk/tjDHA==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.13.0"
+    "@typescript-eslint/typescript-estree" "2.15.0"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/parser@^2.12.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.13.0.tgz#ea1ab394cf9ca17467e3da7f96eca9309f57c326"
-  integrity sha512-vbDeLr5QRJ1K7x5iRK8J9wuGwR9OVyd1zDAY9XFAQvAosHVjSVbDgkm328ayE6hx2QWVGhwvGaEhedcqAbfQcA==
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.15.0.tgz#379a71a51b0429bc3bc55c5f8aab831bf607e411"
+  integrity sha512-6iSgQsqAYTaHw59t0tdjzZJluRAjswdGltzKEdLtcJOxR2UVTPHYvZRqkAVGCkaMVb6Fpa60NnuozNCvsSpA9g==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.13.0"
-    "@typescript-eslint/typescript-estree" "2.13.0"
+    "@typescript-eslint/experimental-utils" "2.15.0"
+    "@typescript-eslint/typescript-estree" "2.15.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.13.0.tgz#a2e746867da772c857c13853219fced10d2566bc"
-  integrity sha512-t21Mg5cc8T3ADEUGwDisHLIubgXKjuNRbkpzDMLb7/JMmgCe/gHM9FaaujokLey+gwTuLF5ndSQ7/EfQqrQx4g==
+"@typescript-eslint/typescript-estree@2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.15.0.tgz#79ae52eed8701b164d91e968a65d85a9105e76d3"
+  integrity sha512-L6Pog+w3VZzXkAdyqA0VlwybF8WcwZX+mufso86CMxSdWmcizJ38lgBdpqTbc9bo92iyi0rOvmATKiwl+amjxg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -3308,14 +3272,14 @@ browserslist@4.7.0:
     electron-to-chromium "^1.3.247"
     node-releases "^1.1.29"
 
-browserslist@^4.6.0, browserslist@^4.8.0, browserslist@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.2.tgz#b45720ad5fbc8713b7253c20766f701c9a694289"
-  integrity sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==
+browserslist@^4.6.0, browserslist@^4.8.0, browserslist@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.3.tgz#65802fcd77177c878e015f0e3189f2c4f627ba44"
+  integrity sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==
   dependencies:
-    caniuse-lite "^1.0.30001015"
+    caniuse-lite "^1.0.30001017"
     electron-to-chromium "^1.3.322"
-    node-releases "^1.1.42"
+    node-releases "^1.1.44"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -3495,10 +3459,10 @@ can-use-dom@^0.1.0:
   resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
-caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001015:
-  version "1.0.30001017"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001017.tgz#d3ad6ec18148b9bd991829958d9d7e562bb78cd6"
-  integrity sha512-EDnZyOJ6eYh6lHmCvCdHAFbfV4KJ9lSdfv4h/ppEhrU/Yudkl7jujwMZ1we6RX7DXqBfT04pVMQ4J+1wcTlsKA==
+caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001017:
+  version "1.0.30001019"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz#857e3fccaad2b2feb3f1f6d8a8f62d747ea648e1"
+  integrity sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3787,9 +3751,9 @@ commander@^2.11.0, commander@^2.12.1, commander@^2.19.0, commander@^2.20.0, comm
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.0.1.tgz#b67622721785993182e807f4883633e6401ba53c"
-  integrity sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
+  integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -3890,17 +3854,17 @@ copy-to-clipboard@^3.0.8:
     toggle-selection "^1.0.6"
 
 core-js-compat@^3.1.1, core-js-compat@^3.6.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.1.tgz#39638c935c83c93a793abb628b252ec43e85783a"
-  integrity sha512-2Tl1EuxZo94QS2VeH28Ebf5g3xbPZG/hj/N5HDDy4XMP/ImR0JIer/nggQRiMN91Q54JVkGbytf42wO29oXVHg==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.2.tgz#314ca8b84d5e71c27c19f1ecda966501b1cf1f10"
+  integrity sha512-+G28dzfYGtAM+XGvB1C5AS1ZPKfQ47HLhcdeIQdZgQnJVdp7/D0m+W/TErwhgsX6CujRUk/LebB6dCrKrtJrvQ==
   dependencies:
-    browserslist "^4.8.2"
+    browserslist "^4.8.3"
     semver "7.0.0"
 
 core-js-pure@^3.0.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.1.tgz#59acfb71caf2fb495aae4c1a0b2a7f2c1b65267e"
-  integrity sha512-yKiUdvQWq66xUc408duxUCxFHuDfz5trF5V4xnQzb8C7P/5v2gFUdyNWQoevyAeGYB1hl1X/pzGZ20R3WxZQBA==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.2.tgz#81f08059134d1c7318838024e1b8e866bcb1ddb3"
+  integrity sha512-PRasaCPjjCB65au2dMBPtxuIR6LM8MVNdbIbN57KxcDV1FAYQWlF0pqje/HC2sM6nm/s9KqSTkMTU75pozaghA==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -3913,9 +3877,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-js@^3.0.1, core-js@^3.0.4, core-js@^3.5.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.1.tgz#39d5e2e346258cc01eb7d44345b1c3c014ca3f05"
-  integrity sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.2.tgz#2799ea1a59050f0acf50dfe89b916d6503b16caa"
+  integrity sha512-hIE5dXkRzRvnZ5vhkRfQxUvDxQZmD9oueA08jDYRBKJHx+VIl/Pne/e0A4x9LObEEthC/TqiZybUoNM4tRgnKg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4044,9 +4008,9 @@ crypto-browserify@^3.11.0:
     randomfill "^1.0.3"
 
 css-loader@^3.0.0, css-loader@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.4.0.tgz#9fb263436783117a41d014e45e8eaeba54dd6670"
-  integrity sha512-JornYo4RAXl1Mzt0lOSVPmArzAMV3rGY2VuwtaDc732WTWjdwTaeS19nCGWMcSCf305Q396lhhDAJEWWM0SgPQ==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.4.1.tgz#dfb7968aa9bffb26bd20375afdffe77d5a234b77"
+  integrity sha512-+ybmv7sVxxNEenQhkifQDvny/1iNQM7YooJbSfVUdQQvisyg1aKIqgGjCjoFSyVLJMp17z9rfZFQaR5HGHcMbw==
   dependencies:
     camelcase "^5.3.1"
     cssesc "^3.0.0"
@@ -4375,13 +4339,6 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
 dom-serializer@0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
@@ -4503,9 +4460,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.322:
-  version "1.3.322"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz#a6f7e1c79025c2b05838e8e344f6e89eb83213a8"
-  integrity sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==
+  version "1.3.328"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.328.tgz#a619575c42f1d5b443103664f25ffa5a80190ee5"
+  integrity sha512-x4XefnFxDxFwaQ01d/pppJP9meWhOIJ/gtI6/4jqkpsadq79uL7NYSaX64naLmJqvzUBjSrO3IM2+1b/W9KdPg==
 
 element-resize-detector@^1.1.15:
   version "1.1.15"
@@ -4692,7 +4649,7 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -4703,9 +4660,9 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@^1.9.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.0.tgz#f763daf840af172bb3a2b6dd7219c0e17f7ff541"
-  integrity sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.1.tgz#08770602a74ac34c7a90ca9229e7d51e379abc76"
+  integrity sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
@@ -6202,9 +6159,9 @@ inquirer@^6.2.0:
     through "^2.3.6"
 
 inquirer@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.1.tgz#13f7980eedc73c689feff3994b109c4e799c6ebb"
-  integrity sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.3.tgz#f9b4cd2dff58b9f73e8d43759436ace15bed4567"
+  integrity sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==
   dependencies:
     ansi-escapes "^4.2.1"
     chalk "^2.4.2"
@@ -7401,7 +7358,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -7533,11 +7490,6 @@ markdown-to-jsx@^6.9.1, markdown-to-jsx@^6.9.3:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-material-colors@^1.2.1:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
-  integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
-
 math-random@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
@@ -7570,11 +7522,6 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
-
-memoize-one@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
-  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memoizerific@^1.11.3:
   version "1.11.3"
@@ -7703,17 +7650,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
-  integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
 mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.25"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.25.tgz#39772d46621f93e2a80a856c53b86a62156a6437"
-  integrity sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
   dependencies:
-    mime-db "1.42.0"
+    mime-db "1.43.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -8070,7 +8017,7 @@ node-pre-gyp@*:
     semver "^5.3.0"
     tar "^4.4.2"
 
-node-releases@^1.1.29, node-releases@^1.1.42:
+node-releases@^1.1.29, node-releases@^1.1.44:
   version "1.1.44"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.44.tgz#cd66438a6eb875e3eb012b6a12e48d9f4326ffd7"
   integrity sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==
@@ -8460,9 +8407,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
-  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
   dependencies:
     p-try "^2.0.0"
 
@@ -8701,9 +8648,9 @@ performance-now@^2.1.0:
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 picomatch@^2.0.5:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
-  integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
+  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -8869,9 +8816,9 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2:
   integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
 
 postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.25"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.25.tgz#dd2a2a753d50b13bed7a2009b4a18ac14d9db21e"
-  integrity sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==
+  version "7.0.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
+  integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -8927,7 +8874,14 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.8.4, prismjs@~1.17.0:
+prismjs@^1.8.4:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.18.0.tgz#8f04dd47fa232cbd27d1ca969107580ff43f06e4"
+  integrity sha512-N0r3i/Cto516V8+GKKamhsPVZSFcO0TMUBtIDW6uq6BVqoC3FNtZVZ+cmH16N2XtGQlgRN+sFUTjOdCsEP51qw==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
+prismjs@~1.17.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
   integrity sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==
@@ -8994,7 +8948,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9197,18 +9151,6 @@ react-clientside-effect@^1.2.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-react-color@^2.17.0:
-  version "2.17.3"
-  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.17.3.tgz#b8556d744f95193468c7061d2aa19180118d4a48"
-  integrity sha512-1dtO8LqAVotPIChlmo6kLtFS1FP89ll8/OiA8EcFRDR+ntcK+0ukJgByuIQHRtzvigf26dV5HklnxDIvhON9VQ==
-  dependencies:
-    "@icons/material" "^0.2.4"
-    lodash "^4.17.11"
-    material-colors "^1.2.1"
-    prop-types "^15.5.10"
-    reactcss "^1.2.0"
-    tinycolor2 "^1.4.1"
-
 react-dev-utils@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-9.1.0.tgz#3ad2bb8848a32319d760d0a84c56c14bdaae5e81"
@@ -9250,9 +9192,9 @@ react-docgen-typescript-loader@^3.6.0:
     react-docgen-typescript "^1.15.0"
 
 react-docgen-typescript@^1.15.0:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.16.1.tgz#3c4570601b2e765280adf570a0f344b35111604d"
-  integrity sha512-r2FyrOa9ynupwKzufHn8IqhWt8aYts3TZz/LWzJGFMyH8AaHQ/Z4LY+fbaI5Gs46DmeyNJvzg2dDELV2k/bL0A==
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.16.2.tgz#d5f26ba6591ac4bc61628c514d492de461ae7c2c"
+  integrity sha512-nECrg2qih81AKp0smkxXebF72/2EjmEn7gXSlWLDHLbpGcbw2yIorol24fw1FWqvndIY82sfSd0x/SyfMKY1Jw==
 
 react-docgen@^4.1.1:
   version "4.1.1"
@@ -9323,13 +9265,6 @@ react-hotkeys@2.0.0-pre4:
   dependencies:
     prop-types "^15.6.1"
 
-react-input-autosize@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
-  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
-  dependencies:
-    prop-types "^15.5.8"
-
 react-inspector@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-3.0.2.tgz#c530a06101f562475537e47df428e1d7aff16ed8"
@@ -9382,20 +9317,6 @@ react-redux@^7.0.2:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
-react-select@^3.0.0:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
-  integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    react-input-autosize "^2.2.2"
-    react-transition-group "^2.2.1"
-
 react-sizeme@^2.5.2, react-sizeme@^2.6.7:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.10.tgz#9993dcb5e67fab94a8e5d078a0d3820609010f17"
@@ -9435,16 +9356,6 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^2.2.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
-
 react@^16.8.3:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
@@ -9453,13 +9364,6 @@ react@^16.8.3:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-reactcss@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
-  integrity sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==
-  dependencies:
-    lodash "^4.0.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -9515,9 +9419,9 @@ read-pkg@^5.1.1, read-pkg@^5.2.0:
     type-fest "^0.6.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -9860,9 +9764,9 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2, resolve@^1.8.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.1.tgz#9e018c540fcf0c427d678b9931cbf45e984bcaff"
-  integrity sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
+  integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
   dependencies:
     path-parse "^1.0.6"
 
@@ -10857,9 +10761,9 @@ terser-webpack-plugin@^2.3.0:
     webpack-sources "^1.4.3"
 
 terser@^4.1.2, terser@^4.3.9, terser@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.4.3.tgz#401abc52b88869cf904412503b1eb7da093ae2f0"
-  integrity sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.1.tgz#913e35e0d38a75285a7913ba01d753c4089ebdbd"
+  integrity sha512-w0f2OWFD7ka3zwetgVAhNMeyzEbj39ht2Tb0qKflw9PmW9Qbo5tjTh01QJLkhO9t9RDDQYvk+WXqpECI2C6i2A==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -10914,11 +10818,6 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-
-tinycolor2@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -11192,9 +11091,9 @@ ua-parser-js@^0.7.18:
   integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
 
 uglify-js@^3.1.4:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.3.tgz#f918fce9182f466d5140f24bb0ff35c2d32dcc6a"
-  integrity sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.4.tgz#e6d83a1aa32ff448bd1679359ab13d8db0fe0743"
+  integrity sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"


### PR DESCRIPTION
# Hugh/navigation-redesign

## [Version 0.1.19](https://www.npmjs.com/package/@f-design/component-library)

### Description

A general redesign of the navigation components for the library. Transitions have been polished, colors re-examined, and a dark theme has been started! 👻 

There were also some wonky bugs/errors with webpack and TypeScript that have since been resolved and will now allow for intellisense when pulling the library into another repo! 🎉 

### Changes

- Adds cool gray color palette

**Storybook**
- Removes knobs
- Rewrites `ExpansionPanel` stories

**Components**
- Completely rebuilds/redesigns `ExpansionPanel`
- Redesigns and adds dark theme for `HeaderMenu` and `SideNavigation`
- Fixes `Button` loading styles

### Fixes

- Webpack bundling
- TypeScript intellisense

### Checklist
- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
- [x] There are no incidental style changes