### PR TITLE
Hugh/textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -32,7 +32,7 @@ storiesOf('Button', module)
     </div>
   ))
   .add('Disabled', () => (
-    <div>
+    <div className="story__button-container">
       <Button onClick={mockClick} disabled>
         Default
       </Button>
@@ -57,7 +57,7 @@ storiesOf('Button', module)
     </div>
   ))
   .add('Loading', () => (
-    <div>
+    <div className="story__button-container">
       <Button onClick={mockClick} loading>
         Default
       </Button>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -23,6 +23,7 @@ const Checkbox: FunctionComponent<CheckboxProps> = ({
   options,
   label,
   other,
+  className,
 }: CheckboxProps) => (
   <div
     className={classnames({

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -9,6 +9,7 @@ type CheckboxProps = {
   options: CheckboxOption[];
   label?: string;
   other?: OtherOptionType;
+  className?: string;
 };
 
 type CheckboxOption = {
@@ -23,7 +24,12 @@ const Checkbox: FunctionComponent<CheckboxProps> = ({
   label,
   other,
 }: CheckboxProps) => (
-  <div className="fd-checkbox">
+  <div
+    className={classnames({
+      'fd-checkbox': true,
+      [className as string]: className,
+    })}
+  >
     {label && <span className="fd-label">{label}</span>}
 
     {options.map(({ label, checked, disabled }) => (

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -7,7 +7,7 @@ import React, {
 import classnames from 'classnames';
 
 type ExpansionPanelProps = {
-  children: ReactChild | ReactChild[];
+  children: ReactChild | ReactChild[] | boolean;
   title?: string;
   expanded?: boolean;
   className?: string;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -25,10 +25,12 @@ const Input: FunctionComponent<InputProps> = ({
   min,
   max,
   disabled,
+  className,
 }: InputProps) => (
   <div
     className={classnames({
       'fd-input': true,
+      [className as string]: className,
     })}
   >
     {label && <span className="fd-label">{label}</span>}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -12,6 +12,7 @@ type InputProps = {
   min?: string;
   max?: string;
   disabled?: boolean;
+  className?: string;
 };
 
 const Input: FunctionComponent<InputProps> = ({

--- a/src/components/Loaders/CircleLoader/CircleLoader.tsx
+++ b/src/components/Loaders/CircleLoader/CircleLoader.tsx
@@ -19,12 +19,10 @@ const CircleLoader: FunctionComponent<CircleLoaderProps> = ({
 
   return (
     <div
-      className={
-        (classname = {
-          'fd-circle-loader': true,
-          [className as string]: className,
-        })
-      }
+      className={classnames({
+        'fd-circle-loader': true,
+        [className as string]: className,
+      })}
       style={wrapperStyles}
     >
       <div className="fd-circle-loader__container">

--- a/src/components/Loaders/CircleLoader/CircleLoader.tsx
+++ b/src/components/Loaders/CircleLoader/CircleLoader.tsx
@@ -1,13 +1,16 @@
 import React, { FunctionComponent } from 'react';
+import classnames from 'classnames';
 
 type CircleLoaderProps = {
   size?: string | number;
   color?: string;
+  className?: string;
 };
 
 const CircleLoader: FunctionComponent<CircleLoaderProps> = ({
   size,
   color,
+  className,
 }: CircleLoaderProps) => {
   const wrapperStyles = {
     height: `${size}`,
@@ -15,7 +18,15 @@ const CircleLoader: FunctionComponent<CircleLoaderProps> = ({
   };
 
   return (
-    <div className="fd-circle-loader" style={wrapperStyles}>
+    <div
+      className={
+        (classname = {
+          'fd-circle-loader': true,
+          [className as string]: className,
+        })
+      }
+      style={wrapperStyles}
+    >
       <div className="fd-circle-loader__container">
         <svg className="fd-circle-loader__svg" viewBox=" 25 25 50 50">
           <circle

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -20,6 +20,7 @@ type HeaderMenuProps = {
   defaultTitle: string;
   onNavigate?: (currentlyViewing: CurrentlyViewing) => void;
   goDark?: boolean;
+  className?: string;
 };
 
 const getBaseClassName = (goDark: boolean | undefined): string =>
@@ -31,6 +32,7 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
   onNavigate,
   defaultTitle,
   goDark,
+  className,
 }: HeaderMenuProps) => {
   const [baseClassName] = useState(getBaseClassName(goDark));
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -292,7 +294,12 @@ const HeaderMenu: FunctionComponent<HeaderMenuProps> = ({
   );
 
   return (
-    <div className={`${baseClassName}`}>
+    <div
+      className={classnames({
+        [`${baseClassName}`]: true,
+        [className as string]: className,
+      })}
+    >
       <div className={`${baseClassName}__left`}>
         <div className={`${baseClassName}__location-container`}>
           {currentlyViewing && renderCurrentlyViewingHeader(currentlyViewing)}

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -31,13 +31,15 @@ type SideNavigationProps = {
 };
 
 type SideNavigationSelection = {
-  option: string;
-  subOption?: string | undefined;
+  option?: string;
+  subOption?: string;
 };
 
-const getSelection = (props: SideNavigationProps): SideNavigationSelection => {
-  const { currentlyViewing, menuOptions, defaultSelected } = props;
-
+const getSelection = (
+  currentlyViewing: CurrentlyViewing,
+  menuOptions: SideNavigationOption[],
+  fallBack: SideNavigationSelection
+): SideNavigationSelection => {
   const preSelection = menuOptions.reduce(
     (accumulator, { path, label, subOptions }: SideNavigationOption) => {
       if (path && path === currentlyViewing.path) {
@@ -62,7 +64,7 @@ const getSelection = (props: SideNavigationProps): SideNavigationSelection => {
 
       return accumulator;
     },
-    defaultSelected as SideNavigationSelection
+    fallBack as SideNavigationSelection
   );
 
   return preSelection;
@@ -84,6 +86,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
     onNavigate,
     logoAssetPath,
     logoTitle,
+    defaultSelected,
     goDark,
   } = props;
 
@@ -96,11 +99,14 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   >([]);
   const [isCollapsed, toggleCollapsed] = useState(collapsed);
   const [selection, setSelection] = useState<SideNavigationSelection>(
-    getSelection(props)
+    getSelection(currentlyViewing, menuOptions, defaultSelected)
   );
 
   useEffect(() => {
-    const newSelection = getSelection(props);
+    const newSelection = getSelection(currentlyViewing, menuOptions, {
+      option: undefined,
+      subOption: undefined,
+    });
 
     if (
       newSelection.option !== selection.option ||
@@ -168,7 +174,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
   };
 
   const handleUpdateSelection = (
-    newOption: string,
+    newOption: string | undefined,
     newSubOption: string | undefined
   ): void => {
     setSelection({

--- a/src/components/Navigation/SideNavigation/SideNavigation.tsx
+++ b/src/components/Navigation/SideNavigation/SideNavigation.tsx
@@ -28,6 +28,7 @@ type SideNavigationProps = {
   logoAssetPath?: string;
   logoTitle?: string;
   goDark?: boolean;
+  className?: string;
 };
 
 type SideNavigationSelection = {
@@ -88,6 +89,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
     logoTitle,
     defaultSelected,
     goDark,
+    className,
   } = props;
 
   const [baseClassName] = useState(getBaseClassName(goDark));
@@ -457,6 +459,7 @@ const SideNavigation: FunctionComponent<SideNavigationProps> = (
       className={classnames({
         [`${baseClassName}`]: true,
         [`${baseClassName}-collapsed`]: isCollapsed,
+        [className as string]: className,
       })}
     >
       {hasHeader && (

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -11,6 +11,7 @@ type RadioProps = {
   label?: string;
   other?: OtherOptionType;
   disabled?: boolean;
+  className?: string;
 };
 
 const Radio: FunctionComponent<RadioProps> = ({
@@ -20,8 +21,14 @@ const Radio: FunctionComponent<RadioProps> = ({
   label,
   other,
   disabled,
+  className,
 }: RadioProps) => (
-  <div className="fd-radio">
+  <div
+    className={classnames({
+      'fd-radio': true,
+      [className as string]: className,
+    })}
+  >
     {label && <span className="fd-label">{label}</span>}
 
     {options.map(option => (

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -22,7 +22,7 @@ storiesOf('Select', module)
         <Select
           label="Label"
           selected={selected}
-          onClick={mockOnClick}
+          onSelect={mockOnClick}
           options={[
             { value: 'huey', label: 'Huhu' },
             { value: 'juliana', label: 'Juju' },
@@ -38,7 +38,7 @@ storiesOf('Select', module)
             value: 'disabled',
             label: 'Locked',
           }}
-          onClick={mockOnClick}
+          onSelect={mockOnClick}
           options={[
             { value: 'huey', label: 'Huhu' },
             { value: 'juliana', label: 'Juju' },

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { SelectOptionType } from '../../types';
 
 type SelectProps = {
-  onClick: (option: SelectOptionType) => void;
+  onSelect: (option: SelectOptionType) => void;
   selected?: SelectOptionType;
   options?: SelectOptionType[];
   id?: string;
@@ -17,7 +17,7 @@ type SelectProps = {
 
 const Select: FunctionComponent<SelectProps> = ({
   selected,
-  onClick,
+  onSelect,
   options,
   id,
   label,
@@ -86,7 +86,7 @@ const Select: FunctionComponent<SelectProps> = ({
               })}
               onClick={(): void => {
                 toggleShowOptions(false);
-                onClick(option);
+                onSelect(option);
               }}
               value={option.value}
             >

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -12,6 +12,7 @@ type SelectProps = {
   placeholder?: string;
   disabled?: boolean;
   multiple?: boolean;
+  className?: string;
 };
 
 const Select: FunctionComponent<SelectProps> = ({
@@ -22,11 +23,18 @@ const Select: FunctionComponent<SelectProps> = ({
   label,
   placeholder,
   disabled,
+  className,
 }: SelectProps) => {
   const [areOptionsShown, toggleShowOptions] = useState(false);
 
   return (
-    <div id={id} className="fd-select">
+    <div
+      id={id}
+      className={classnames({
+        'fd-select': true,
+        [className as string]: className,
+      })}
+    >
       {label && <span className="fd-label">{label}</span>}
 
       <div

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,17 @@
+import React, { useState, ChangeEvent } from 'react';
+import { withA11y } from '@storybook/addon-a11y';
+import { storiesOf } from '@storybook/react';
+
+import TextArea from './TextArea';
+
+storiesOf('TextArea', module)
+  .addDecorator(withA11y)
+  .add('Default', () => {
+    const [value, updateValue] = useState('');
+
+    const handleChange = ({
+      target: { value },
+    }: ChangeEvent<HTMLTextAreaElement>): void => updateValue(value);
+
+    return <TextArea name="default" value={value} onChange={handleChange} />;
+  });

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -13,5 +13,31 @@ storiesOf('TextArea', module)
       target: { value },
     }: ChangeEvent<HTMLTextAreaElement>): void => updateValue(value);
 
-    return <TextArea name="default" value={value} onChange={handleChange} />;
+    return (
+      <TextArea
+        name="default"
+        label="Label"
+        value={value}
+        onChange={handleChange}
+      />
+    );
+  })
+  .add('Disabled', () => {
+    const [value, updateValue] = useState(
+      'You will never change me! MWAAAAHAHAHAHAHAHA!'
+    );
+
+    const handleChange = ({
+      target: { value },
+    }: ChangeEvent<HTMLTextAreaElement>): void => updateValue(value);
+
+    return (
+      <TextArea
+        disabled
+        name="default"
+        label="Label"
+        value={value}
+        onChange={handleChange}
+      />
+    );
   });

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,0 +1,47 @@
+import React, { FunctionComponent, ChangeEvent } from 'react';
+
+type TextAreaProps = {
+  name: string;
+  value: string;
+  onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+  id?: string;
+  label?: string;
+  placeholder?: string;
+  min?: number;
+  max?: number;
+  disabled?: boolean;
+};
+
+const TextArea: FunctionComponent<TextAreaProps> = ({
+  name,
+  value,
+  onChange,
+  id,
+  label,
+  placeholder,
+  min,
+  max,
+  disabled,
+}: TextAreaProps) => (
+  <div className="fd-textarea">
+    {label && <span className="fd-label">{label}</span>}
+
+    <textarea
+      id={id}
+      name={name}
+      value={value}
+      placeholder={placeholder}
+      onChange={onChange}
+      minLength={min}
+      maxLength={max}
+      disabled={disabled}
+      className="fd-textarea__input"
+    />
+  </div>
+);
+
+TextArea.defaultProps = {
+  placeholder: 'Enter a value...',
+};
+
+export default TextArea;

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, ChangeEvent } from 'react';
+import classnames from 'classnames';
 
 type TextAreaProps = {
   name: string;
@@ -10,6 +11,7 @@ type TextAreaProps = {
   min?: number;
   max?: number;
   disabled?: boolean;
+  className?: string;
 };
 
 const TextArea: FunctionComponent<TextAreaProps> = ({
@@ -22,8 +24,14 @@ const TextArea: FunctionComponent<TextAreaProps> = ({
   min,
   max,
   disabled,
+  className,
 }: TextAreaProps) => (
-  <div className="fd-textarea">
+  <div
+    className={classnames({
+      'fd-textarea': true,
+      [className as string]: className,
+    })}
+  >
     {label && <span className="fd-label">{label}</span>}
 
     <textarea

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -163,4 +163,8 @@
       top: 0.25rem;
     }
   }
+  &__value {
+    display: flex;
+    align-content: center;
+  }
 }

--- a/src/styles/components/Checkbox.scss
+++ b/src/styles/components/Checkbox.scss
@@ -22,17 +22,7 @@
     }
   }
   &__input {
-    // Hide checkbox visually but remain accessible to screen readers.
-    // Source: https://polished.js.org/docs/#hidevisually
-    position: absolute;
-    height: 1px;
-    width: 1px;
-    margin: -1px;
-    padding: 0;
-    border: 0;
-    clip: rect(0 0 0 0);
-    overflow: hidden;
-    white-space: nowrap;
+    @include hide-visually;
     &:focus + .fd-checkbox__styled {
       @include focus-styles;
     }

--- a/src/styles/components/ExpansionPanel.scss
+++ b/src/styles/components/ExpansionPanel.scss
@@ -9,7 +9,7 @@
     + .fd-expansion-panel::before {
       @include gradientPseudoBorderTop;
     }
-    &:last-of-type::after {
+    &:last-child::after {
       @include gradientPseudoBorderBottom;
     }
   }

--- a/src/styles/components/OtherOption.scss
+++ b/src/styles/components/OtherOption.scss
@@ -23,7 +23,7 @@
   &__underline {
     position: absolute;
     right: 35%;
-    bottom: -1px;
+    bottom: 0;
     left: 40%;
     height: 1px;
     background-color: $brand-color;

--- a/src/styles/components/OtherOption.scss
+++ b/src/styles/components/OtherOption.scss
@@ -23,7 +23,7 @@
   &__underline {
     position: absolute;
     right: 35%;
-    bottom: 0;
+    bottom: -1px;
     left: 40%;
     height: 1px;
     background-color: $brand-color;

--- a/src/styles/components/Radio.scss
+++ b/src/styles/components/Radio.scss
@@ -13,7 +13,7 @@
     }
   }
   &__input {
-    display: none;
+    @include hide-visually;
     &:checked + .fd-radio__styled:before {
       border-color: $brand-color;
       animation: ripple 0.2s linear forwards;

--- a/src/styles/components/TextArea.scss
+++ b/src/styles/components/TextArea.scss
@@ -1,0 +1,23 @@
+@import '../colors';
+@import '../mixins';
+
+.fd-textarea {
+  display: flex;
+  flex-direction: column;
+  &__input {
+    @include input-base-styles;
+    min-height: 7rem;
+    max-width: 32rem;
+    resize: vertical;
+    &:disabled {
+      background-color: $gray-03;
+      cursor: not-allowed;
+    }
+    &::placeholder {
+      color: $gray-06;
+    }
+    &:focus {
+      @include focus-styles;
+    }
+  }
+}

--- a/src/styles/components/all.scss
+++ b/src/styles/components/all.scss
@@ -9,3 +9,4 @@
 @import './Radio';
 @import './Select';
 @import './SideNavigation';
+@import './TextArea.scss';

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -43,6 +43,20 @@
   top: 0;
 }
 
+@mixin hide-visually {
+  // Hide checkbox visually but remain accessible to screen readers.
+  // Source: https://polished.js.org/docs/#hidevisually
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 // Check-mark animation influenced by and tweaked from
 // https://codepen.io/scottloway/pen/zqoLyQ
 @mixin check-mark-animation(

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -12,7 +12,7 @@
 
 @mixin input-base-styles {
   height: 2.5rem;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem;
   border: 1px solid $gray-09;
   border-radius: 0.25rem;
   font-size: 1rem;


### PR DESCRIPTION
# Hugh/textarea

## [Version 0.1.33](https://www.npmjs.com/package/@f-design/component-library)

### Description

Adds a `TextArea` component and implements various updates to other components.

### Changes

**Components**
- Builds the `TextArea` component
- Adds a `className` prop to all components that needed it
- Updates `getSelection` in `SideNavigation` to use a passed fallback instead of defaulting to `defaultSelected`, which allows an empty state to be used
- Updates `Select` to use `onSelect` instead of `onClick`
- Updates `ExpansionPanel` to accept conditionally rendered children

**Styling**
- Touches up `Button`, `ExpansionPanel`, and `Input` styling
- Builds a `hide-visually` mixin

### Checklist
- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
- [x] There are no incidental style changes