### PR TITLE
Hugh/errors cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -87,4 +87,38 @@ storiesOf('Checkbox', module)
         />
       </div>
     );
+  })
+  .add('Error', () => {
+    const [options, updateOptions] = useState([
+      { checked: false, label: 'Cat' },
+      { checked: false, label: 'Dog' },
+      { checked: false, label: 'Gold Fish' },
+      { checked: false, label: 'Guinea Pig' },
+      { checked: false, label: 'Hedgehog' },
+      { checked: false, label: 'Ocelot' },
+      { checked: false, label: 'Cthulhu' },
+    ]);
+
+    const handleChange = ({
+      target: { name, checked },
+    }: ChangeEvent<HTMLInputElement>): void => {
+      const newOptions = options.map(option =>
+        option.label === name ? { ...option, checked } : option
+      );
+
+      updateOptions(newOptions);
+    };
+
+    const hasOptionChecked = options.find(({ checked }) => checked);
+
+    return (
+      <div style={{ display: 'flex ' }}>
+        <Checkbox
+          label="Label"
+          onChange={handleChange}
+          options={options}
+          errorMessage={!hasOptionChecked ? 'Please pick a favorite pet' : ''}
+        />
+      </div>
+    );
   });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -81,7 +81,7 @@ const Checkbox: FunctionComponent<CheckboxProps> = ({
       ))}
     </div>
 
-    <p className="fd-checkbox__error">{errorMessage}</p>
+    <p className="fd-input-error">{errorMessage}</p>
   </div>
 );
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -10,6 +10,7 @@ type CheckboxProps = {
   label?: string;
   other?: OtherOptionType;
   className?: string;
+  errorMessage?: string;
 };
 
 type CheckboxOption = {
@@ -24,6 +25,7 @@ const Checkbox: FunctionComponent<CheckboxProps> = ({
   label,
   other,
   className,
+  errorMessage,
 }: CheckboxProps) => (
   <div
     className={classnames({
@@ -33,44 +35,53 @@ const Checkbox: FunctionComponent<CheckboxProps> = ({
   >
     {label && <span className="fd-label">{label}</span>}
 
-    {options.map(({ label, checked, disabled }) => (
-      <label
-        key={`fd-checkbox__${label}`}
-        className={classnames({
-          'fd-checkbox__container': true,
-          'fd-checkbox__container-disabled': disabled,
-        })}
-      >
-        <input
-          className="fd-checkbox__input"
-          type="checkbox"
-          name={label}
-          checked={checked}
-          onChange={onChange}
-          disabled={disabled}
-        />
-        <div
+    <div
+      className={classnames({
+        'fd-checkbox__inputs-container': true,
+        'fd-checkbox__inputs-container-error': errorMessage,
+      })}
+    >
+      {options.map(({ label, checked, disabled }) => (
+        <label
+          key={`fd-checkbox__${label}`}
           className={classnames({
-            'fd-checkbox__styled': true,
-            'fd-checkbox__styled-checked': checked,
-            'fd-checkbox__styled-disabled': disabled,
+            'fd-checkbox__container': true,
+            'fd-checkbox__container-disabled': disabled,
           })}
         >
-          {checked && <div className="fd-checkbox__icon" />}
-        </div>
-        <span>{label}</span>
-
-        {label.toLowerCase() === 'other' && other && (
-          <OtherOption
+          <input
+            className="fd-checkbox__input"
+            type="checkbox"
             name={label}
-            value={other.value}
-            selected={checked}
-            onChange={other.onChange}
+            checked={checked}
+            onChange={onChange}
             disabled={disabled}
           />
-        )}
-      </label>
-    ))}
+          <div
+            className={classnames({
+              'fd-checkbox__styled': true,
+              'fd-checkbox__styled-checked': checked,
+              'fd-checkbox__styled-disabled': disabled,
+            })}
+          >
+            {checked && <div className="fd-checkbox__icon" />}
+          </div>
+          <span>{label}</span>
+
+          {label.toLowerCase() === 'other' && other && (
+            <OtherOption
+              name={label}
+              value={other.value}
+              selected={checked}
+              onChange={other.onChange}
+              disabled={disabled}
+            />
+          )}
+        </label>
+      ))}
+    </div>
+
+    <p className="fd-checkbox__error">{errorMessage}</p>
   </div>
 );
 

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -7,7 +7,7 @@ import React, {
 import classnames from 'classnames';
 
 type ExpansionPanelProps = {
-  children: ReactChild | ReactChild[] | boolean;
+  children: ReactChild | ReactChild[] | (boolean | ReactChild)[];
   title?: string;
   expanded?: boolean;
   className?: string;

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -9,6 +9,7 @@ storiesOf('Input', module)
   .add('Types', () => {
     const [value, handleChangeTextValue] = useState('');
     const [percentage, handleChangePercentage] = useState('');
+    const [errorValue, handleChangeErrorValue] = useState('');
 
     const mockOnChange = ({
       target: { value, name },
@@ -20,6 +21,10 @@ storiesOf('Input', module)
 
       if (name === 'number') {
         handleChangePercentage(value);
+      }
+
+      if (name === 'errorValue') {
+        handleChangeErrorValue(value);
       }
     };
 
@@ -44,11 +49,19 @@ storiesOf('Input', module)
         />
 
         <Input
-          value={value}
+          value={''}
           name="disabled"
           label="Disabled"
-          onChange={mockOnChange}
+          onChange={(): void => console.log('Disabled')}
           disabled
+        />
+
+        <Input
+          value={errorValue}
+          name="errorValue"
+          label="Label"
+          errorMessage={errorValue ? '' : 'Please enter a value'}
+          onChange={mockOnChange}
         />
       </div>
     );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -13,6 +13,7 @@ type InputProps = {
   max?: string;
   disabled?: boolean;
   className?: string;
+  errorMessage?: string;
 };
 
 const Input: FunctionComponent<InputProps> = ({
@@ -27,6 +28,7 @@ const Input: FunctionComponent<InputProps> = ({
   max,
   disabled,
   className,
+  errorMessage,
 }: InputProps) => (
   <div
     className={classnames({
@@ -47,8 +49,11 @@ const Input: FunctionComponent<InputProps> = ({
       disabled={disabled}
       className={classnames({
         'fd-input__input': true,
+        'fd-input__input-error': errorMessage,
       })}
     />
+
+    <p className="fd-input-error">{errorMessage}</p>
   </div>
 );
 

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState, ChangeEvent } from 'react';
 import { withA11y } from '@storybook/addon-a11y';
 import { storiesOf } from '@storybook/react';
 
+import Button from '../Button/Button';
 import Radio from './Radio';
 
 storiesOf('Radio', module)
@@ -70,6 +71,32 @@ storiesOf('Radio', module)
             handleChangeSelected(event.target.name);
           }}
         />
+      </div>
+    );
+  })
+  .add('Error', () => {
+    const [selected, handleChangeSelected] = useState('');
+
+    return (
+      <div>
+        <Radio
+          label="Pick me!"
+          selected={selected}
+          options={['ME!', 'No, ME!', 'Me, me, me!', 'MEEEEeeeEEE']}
+          onChange={(event): void => {
+            handleChangeSelected(event.target.name);
+          }}
+          errorMessage={selected ? '' : 'You HAVE to pick someone'}
+        />
+
+        <div style={{ marginTop: '1rem' }}>
+          <Button
+            type="destructive"
+            onClick={(): void => handleChangeSelected('')}
+          >
+            Pick no one!
+          </Button>
+        </div>
       </div>
     );
   });

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -12,6 +12,7 @@ type RadioProps = {
   other?: OtherOptionType;
   disabled?: boolean;
   className?: string;
+  errorMessage?: string;
 };
 
 const Radio: FunctionComponent<RadioProps> = ({
@@ -22,6 +23,7 @@ const Radio: FunctionComponent<RadioProps> = ({
   other,
   disabled,
   className,
+  errorMessage,
 }: RadioProps) => (
   <div
     className={classnames({
@@ -31,37 +33,46 @@ const Radio: FunctionComponent<RadioProps> = ({
   >
     {label && <span className="fd-label">{label}</span>}
 
-    {options.map(option => (
-      <label key={option} className="fd-radio__container">
-        <input
-          type="radio"
-          className={classnames({
-            'fd-radio__input': true,
-          })}
-          name={option}
-          onChange={onChange}
-          checked={option === selected}
-          disabled={disabled}
-        />
-        <div
-          className={classnames({
-            'fd-radio__styled': true,
-            'fd-radio__styled-disabled': disabled,
-          })}
-        >
-          {option}
-        </div>
-        {option.toLowerCase() === 'other' && other && (
-          <OtherOption
+    <div
+      className={classnames({
+        'fd-radio__inputs-container': true,
+        'fd-radio__inputs-container-error': errorMessage,
+      })}
+    >
+      {options.map(option => (
+        <label key={option} className="fd-radio__container">
+          <input
+            type="radio"
+            className={classnames({
+              'fd-radio__input': true,
+            })}
             name={option}
-            value={other.value}
-            selected={option === selected}
-            onChange={other.onChange}
+            onChange={onChange}
+            checked={option === selected}
             disabled={disabled}
           />
-        )}
-      </label>
-    ))}
+          <div
+            className={classnames({
+              'fd-radio__styled': true,
+              'fd-radio__styled-disabled': disabled,
+            })}
+          >
+            {option}
+          </div>
+          {option.toLowerCase() === 'other' && other && (
+            <OtherOption
+              name={option}
+              value={other.value}
+              selected={option === selected}
+              onChange={other.onChange}
+              disabled={disabled}
+            />
+          )}
+        </label>
+      ))}
+    </div>
+
+    <p className="fd-input-error">{errorMessage}</p>
   </div>
 );
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -46,6 +46,19 @@ storiesOf('Select', module)
             { value: 'juniper', label: 'Jean-june' },
           ]}
         />
+
+        <Select
+          label="Label"
+          selected={selected}
+          onSelect={mockOnClick}
+          errorMessage="Please pick a Hartigan"
+          options={[
+            { value: 'huey', label: 'Huhu' },
+            { value: 'juliana', label: 'Juju' },
+            { value: 'torin', label: 'Tor-bear' },
+            { value: 'juniper', label: 'Jean-june' },
+          ]}
+        />
       </div>
     );
   });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -13,6 +13,7 @@ type SelectProps = {
   disabled?: boolean;
   multiple?: boolean;
   className?: string;
+  errorMessage?: string;
 };
 
 const Select: FunctionComponent<SelectProps> = ({
@@ -24,6 +25,7 @@ const Select: FunctionComponent<SelectProps> = ({
   placeholder,
   disabled,
   className,
+  errorMessage,
 }: SelectProps) => {
   const [areOptionsShown, toggleShowOptions] = useState(false);
 
@@ -42,6 +44,7 @@ const Select: FunctionComponent<SelectProps> = ({
           'fd-select__container': true,
           'fd-select__container-open': areOptionsShown,
           'fd-select__container-disabled': disabled,
+          'fd-select__container-error': errorMessage,
         })}
         onClick={(): void => {
           if (!disabled) {
@@ -70,11 +73,14 @@ const Select: FunctionComponent<SelectProps> = ({
         </i>
       </div>
 
+      <p className="fd-input-error">{errorMessage}</p>
+
       <div
         className={classnames({
           'fd-select__options-container': true,
           'fd-select__options-container-open': areOptionsShown,
           'fd-select__options-container-with-label': label,
+          'fd-select__options-container-error': errorMessage,
         })}
       >
         {options &&

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -74,6 +74,7 @@ const Select: FunctionComponent<SelectProps> = ({
         className={classnames({
           'fd-select__options-container': true,
           'fd-select__options-container-open': areOptionsShown,
+          'fd-select__options-container-with-label': label,
         })}
       >
         {options &&

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -40,4 +40,22 @@ storiesOf('TextArea', module)
         onChange={handleChange}
       />
     );
+  })
+  .add('Error', () => {
+    const [value, updateValue] = useState('');
+
+    const handleChange = ({
+      target: { value },
+    }: ChangeEvent<HTMLTextAreaElement>): void => updateValue(value);
+
+    return (
+      <TextArea
+        name="default"
+        label="Pirate lore"
+        placeholder="Yarrrr... t'was many moons ago when I..."
+        value={value}
+        onChange={handleChange}
+        errorMessage={value ? '' : 'Write me a story, ye heathen!'}
+      />
+    );
   });

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -12,6 +12,7 @@ type TextAreaProps = {
   max?: number;
   disabled?: boolean;
   className?: string;
+  errorMessage?: string;
 };
 
 const TextArea: FunctionComponent<TextAreaProps> = ({
@@ -25,6 +26,7 @@ const TextArea: FunctionComponent<TextAreaProps> = ({
   max,
   disabled,
   className,
+  errorMessage,
 }: TextAreaProps) => (
   <div
     className={classnames({
@@ -43,8 +45,13 @@ const TextArea: FunctionComponent<TextAreaProps> = ({
       minLength={min}
       maxLength={max}
       disabled={disabled}
-      className="fd-textarea__input"
+      className={classnames({
+        'fd-textarea__input': true,
+        'fd-textarea__input-error': errorMessage,
+      })}
     />
+
+    <p className="fd-input-error">{errorMessage}</p>
   </div>
 );
 

--- a/src/styles/components/Checkbox.scss
+++ b/src/styles/components/Checkbox.scss
@@ -2,6 +2,14 @@
 @import '../mixins';
 
 .fd-checkbox {
+  &__inputs-container {
+    padding: 0.5rem;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    &-error {
+      border-color: $destructive;
+    }
+  }
   &__container {
     position: relative;
     display: flex;
@@ -51,5 +59,8 @@
   }
   &__icon {
     @include check-mark-animation(0.2rem, 0.5rem, 0.125rem);
+  }
+  &__error {
+    @include error-message-styles;
   }
 }

--- a/src/styles/components/Checkbox.scss
+++ b/src/styles/components/Checkbox.scss
@@ -60,7 +60,4 @@
   &__icon {
     @include check-mark-animation(0.2rem, 0.5rem, 0.125rem);
   }
-  &__error {
-    @include error-message-styles;
-  }
 }

--- a/src/styles/components/Errors.scss
+++ b/src/styles/components/Errors.scss
@@ -1,0 +1,7 @@
+.fd-input-error {
+  margin: 0;
+  margin-top: 0.25rem;
+  padding-left: 0.25rem;
+  color: $destructive;
+  font-size: 0.75rem;
+}

--- a/src/styles/components/Errors.scss
+++ b/src/styles/components/Errors.scss
@@ -1,4 +1,5 @@
 .fd-input-error {
+  min-height: 17px;
   margin: 0;
   margin-top: 0.25rem;
   padding-left: 0.25rem;

--- a/src/styles/components/ExpansionPanel.scss
+++ b/src/styles/components/ExpansionPanel.scss
@@ -7,10 +7,10 @@
   flex-direction: column;
   &-with-title {
     + .fd-expansion-panel::before {
-      @include gradientPseudoBorderTop;
+      @include gradient-pseudo-border-top;
     }
     &:last-child::after {
-      @include gradientPseudoBorderBottom;
+      @include gradient-pseudo-border-bottom;
     }
   }
   &__button {

--- a/src/styles/components/Input.scss
+++ b/src/styles/components/Input.scss
@@ -17,5 +17,8 @@
     &:focus {
       @include focus-styles;
     }
+    &-error {
+      border-color: $destructive;
+    }
   }
 }

--- a/src/styles/components/Label.scss
+++ b/src/styles/components/Label.scss
@@ -2,8 +2,4 @@
   margin-bottom: 0.25rem;
   padding-left: 0.25rem;
   font-size: 0.75rem;
-  + .fd-checkbox__container,
-  + .fd-radio__container {
-    margin-top: 0.25rem;
-  }
 }

--- a/src/styles/components/Radio.scss
+++ b/src/styles/components/Radio.scss
@@ -6,6 +6,14 @@
 .fd-radio {
   display: flex;
   flex-direction: column;
+  &__inputs-container {
+    padding: 0.5rem;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    &-error {
+      border-color: $destructive;
+    }
+  }
   &__container {
     display: flex;
     + .fd-radio__container {

--- a/src/styles/components/Select.scss
+++ b/src/styles/components/Select.scss
@@ -24,6 +24,9 @@
       border-radius: 0.25rem 0.25rem 0 0;
       transition: border-radius 0.01s;
     }
+    &-error {
+      border-color: $destructive;
+    }
   }
   &__input {
     flex: 1;
@@ -56,7 +59,9 @@
       min-height: 0;
       max-height: 0;
       padding: 0;
-      visibility: hidden;
+      opacity: 0;
+      transition: min-height 0.01s ease-in-out 0.2s,
+        max-height 0.01s ease-in-out 0.2s, padding 0.01s ease-in-out 0.2s;
     }
     &-open {
       max-height: 12.5rem;
@@ -71,11 +76,15 @@
         min-height: 1.375rem;
         max-height: 1.375rem;
         padding: 0.5rem 1rem;
-        visibility: visible;
+        opacity: 1;
+        transition: 0.01s ease-in-out;
       }
     }
     &-with-label {
       top: 61px;
+    }
+    &-error {
+      border-color: $destructive;
     }
   }
   &__option {

--- a/src/styles/components/Select.scss
+++ b/src/styles/components/Select.scss
@@ -11,8 +11,8 @@
     @include input-base-styles;
     display: flex;
     align-items: center;
+    min-width: 16.75rem;
     padding-right: 0.5rem;
-    display: flex;
     // Closing transition
     transition: border-radius 0.01s ease-in-out 0.2s;
     &-disabled {
@@ -41,6 +41,8 @@
     }
   }
   &__options-container {
+    position: absolute;
+    top: 2.5rem;
     display: flex;
     flex-direction: column;
     min-width: 16.75rem;
@@ -71,6 +73,9 @@
         padding: 0.5rem 1rem;
         visibility: visible;
       }
+    }
+    &-with-label {
+      top: 61px;
     }
   }
   &__option {

--- a/src/styles/components/SideNavigation.scss
+++ b/src/styles/components/SideNavigation.scss
@@ -1,7 +1,8 @@
 @import '../colors';
 @import '../mixins';
 
-.fd-side-navigation, .fd-side-navigation-dark {
+.fd-side-navigation,
+.fd-side-navigation-dark {
   top: 0;
   left: 0;
   right: auto;
@@ -262,7 +263,7 @@
       }
     }
     &::before {
-      @include gradientPseudoBorderTop($white, $gray-04);
+      @include gradient-pseudo-border-top($white, $gray-04);
       width: 80%;
     }
   }

--- a/src/styles/components/TextArea.scss
+++ b/src/styles/components/TextArea.scss
@@ -19,5 +19,8 @@
     &:focus {
       @include focus-styles;
     }
+    &-error {
+      border-color: $destructive;
+    }
   }
 }

--- a/src/styles/components/all.scss
+++ b/src/styles/components/all.scss
@@ -1,6 +1,7 @@
 @import './Button';
 @import './Checkbox';
 @import './CircleLoader';
+@import './Errors.scss';
 @import './ExpansionPanel';
 @import './HeaderMenu';
 @import './Input';

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -10,6 +10,14 @@
   box-shadow: 0 0 3px 2px $destructive-focus-outline;
 }
 
+@mixin error-message-styles {
+  margin: 0;
+  margin-top: 0.25rem;
+  padding-left: 0.25rem;
+  color: $destructive;
+  font-size: 0.75rem;
+}
+
 @mixin input-base-styles {
   height: 2.5rem;
   padding: 0.5rem;
@@ -19,7 +27,7 @@
   box-sizing: border-box;
 }
 
-@mixin gradientPseudoBorder($color-1, $color-2) {
+@mixin gradient-pseudo-border($color-1, $color-2) {
   content: '';
   position: absolute;
   height: 1px;
@@ -33,13 +41,13 @@
   );
 }
 
-@mixin gradientPseudoBorderBottom($color-1: $gray-04, $color-2: $gray-07) {
-  @include gradientPseudoBorder($color-1, $color-2);
+@mixin gradient-pseudo-border-bottom($color-1: $gray-04, $color-2: $gray-07) {
+  @include gradient-pseudo-border($color-1, $color-2);
   bottom: 0;
 }
 
-@mixin gradientPseudoBorderTop($color-1: $gray-04, $color-2: $gray-07) {
-  @include gradientPseudoBorder($color-1, $color-2);
+@mixin gradient-pseudo-border-top($color-1: $gray-04, $color-2: $gray-07) {
+  @include gradient-pseudo-border($color-1, $color-2);
   top: 0;
 }
 
@@ -258,7 +266,7 @@
       }
     }
     &::before {
-      @include gradientPseudoBorderTop($cool-gray-11, $cool-gray-17);
+      @include gradient-pseudo-border-top($cool-gray-11, $cool-gray-17);
     }
   }
   &__collapse-icon {

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -10,14 +10,6 @@
   box-shadow: 0 0 3px 2px $destructive-focus-outline;
 }
 
-@mixin error-message-styles {
-  margin: 0;
-  margin-top: 0.25rem;
-  padding-left: 0.25rem;
-  color: $destructive;
-  font-size: 0.75rem;
-}
-
 @mixin input-base-styles {
   height: 2.5rem;
   padding: 0.5rem;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { ChangeEvent } from 'react';
 
 // FORM
 export interface SelectOptionType {
-  value: string;
+  value: any /*eslint-disable-line @typescript-eslint/no-explicit-any*/;
   label: string;
 }
 


### PR DESCRIPTION
# Hugh/errors-cleanup

## [Version 0.1.36](https://www.npmjs.com/package/@f-design/component-library)

### Description

Adds error states to all relevant components. Updates several things through integration testing. Fixes a bug here, adds an improvement there.

### Changes

**Components**
- Adds error states to `Checkbox/Input/Radio/Select/TextArea`
- Updates `ExpansionPanel` types to accept conditionally rendered children
- Fixes `Select` closing animation

**Styling**
- Adds `Error` styles
- Slight tweaks to `Checkbox/Label/Radio/Select` styles
- Fixes `gradient-pseudo-border` mixins to have the proper casing

### Checklist
- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
- [x] There are no incidental style changes