### PR TITLE
Hugh/pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 - [Wiki](https://github.com/featherweight-design/component-library/wiki/<GH_WIKI_PAGE>)
 - Issues:
-  - [GH_ISSUE_TITLE](https://github.com/featherweight-design/component-library/issues/<ISSUE_NUMBER>)
+  - Resolves featherweight-design/component-library/<ISSUE_NUMBER>
 
 ## Changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# <PR_BRANCH_NAME>
+
+## Description
+
+- [Wiki](https://github.com/featherweight-design/component-library/wiki/<GH_WIKI_PAGE>)
+- Issues:
+  - [GH_ISSUE_TITLE](https://github.com/featherweight-design/component-library/issues/<ISSUE_NUMBER>)
+
+## Changes
+
+- 
+
+## Fixes
+
+- 
+
+## Screenshots
+
+## Checks
+
+- [ ] All tests are passing
+- [ ] There are no linting errors
+- [ ] There are no build errors
+- [ ] There are no incidental style changes
+- [ ] The `CHANGELOG` and version have been updated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 ## Description
 
+- Release version: [<VERSION_NUMBER>](https://www.npmjs.com/package/@f-design/component-library)
 - [Wiki](https://github.com/featherweight-design/component-library/wiki/<GH_WIKI_PAGE>)
 - Issues:
   - Resolves featherweight-design/component-library#<ISSUE_NUMBER>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 - [Wiki](https://github.com/featherweight-design/component-library/wiki/<GH_WIKI_PAGE>)
 - Issues:
-  - Resolves featherweight-design/component-library/<ISSUE_NUMBER>
+  - Resolves featherweight-design/component-library#<ISSUE_NUMBER>
 
 ## Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f-design/component-library",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "A component library built and maintained by Featherweight Design",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
@@ -87,7 +87,6 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run lint",
       "pre-push": "yarn run lint"
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import ExpansionPanel from './components/ExpansionPanel/ExpansionPanel';
 import Input from './components/Input/Input';
 import Radio from './components/Radio/Radio';
 import Select from './components/Select/Select';
+import TextArea from './components/TextArea/TextArea';
 import { CircleLoader } from './components/Loaders';
 import { HeaderMenu, SideNavigation } from './components/Navigation';
 
@@ -17,4 +18,5 @@ export {
   Radio,
   Select,
   SideNavigation,
+  TextArea,
 };

--- a/src/styles/components/Input.scss
+++ b/src/styles/components/Input.scss
@@ -4,7 +4,6 @@
 .fd-input {
   display: flex;
   flex-direction: column;
-  max-width: 16.75rem;
   &__input {
     @include input-base-styles;
     &:disabled {

--- a/src/styles/components/Select.scss
+++ b/src/styles/components/Select.scss
@@ -5,13 +5,11 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  max-width: 16.75rem;
   cursor: pointer;
   &__container {
     @include input-base-styles;
     display: flex;
     align-items: center;
-    min-width: 16.75rem;
     padding-right: 0.5rem;
     // Closing transition
     transition: border-radius 0.01s ease-in-out 0.2s;
@@ -48,7 +46,6 @@
     top: 2.5rem;
     display: flex;
     flex-direction: column;
-    min-width: 16.75rem;
     max-height: 0;
     border: 0px solid transparent;
     box-sizing: border-box;

--- a/src/styles/components/TextArea.scss
+++ b/src/styles/components/TextArea.scss
@@ -7,7 +7,6 @@
   &__input {
     @include input-base-styles;
     min-height: 7rem;
-    max-width: 32rem;
     resize: vertical;
     &:disabled {
       background-color: $gray-03;


### PR DESCRIPTION
# hugh/pr-template

## Description


- Release version: [0.1.37](https://www.npmjs.com/package/@f-design/component-library)
- Issues:
  - Resolves featherweight-design/component-library#11

## Changes

- Adds a PR template

## Fixes

- Fixes `max-width` for `Input/Select/TextArea`
- Fixes export of `TextArea` component

## Checks

- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
- [x] There are no incidental style changes
- [x] The `CHANGELOG` and version have been updated