### PR TITLE
fix: Update webpack to use ts-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,10 +44,10 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        loader: 'awesome-typescript-loader',
+        loader: 'ts-loader',
         exclude: /node_modules/,
         options: {
-          tsconfigPath: 'tsconfig.build.json',
+          configFile: 'tsconfig.build.json',
         },
       },
       {


### PR DESCRIPTION
# `hugh/fix-dist-types`

## Description

- Release version: [0.1.56](https://www.npmjs.com/package/@f-design/component-library)

## Fixes

- Update webpack to use `ts-loader` and add `types.d.ts` to `/dist`

## Sanity Checks

- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
- [x] There are no incidental style changes