### PR TITLE
Hugh button enhancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_development.md
+++ b/.github/ISSUE_TEMPLATE/feature_development.md
@@ -24,7 +24,6 @@ Add any other context or screenshots about the feature request here.
 ## Acceptance Criteria
 
 * [ ] What are the minimum requirements for this feature?
-* [ ] Functional/styling/accessibility implementations?
 
 ## Resources
 

--- a/.github/ISSUE_TEMPLATE/refactor_update.md
+++ b/.github/ISSUE_TEMPLATE/refactor_update.md
@@ -14,7 +14,6 @@ What needs refacotring/updating and why? Any breaking changes?
 ## Acceptance Criteria
 
 * [ ] What do we expect from this refactor/update?
-* [ ] What betterments will come from this?
 
 ## Resources
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-# <PR_BRANCH_NAME>
-
 ## Description
 
 - Release version: [<VERSION_NUMBER>](https://www.npmjs.com/package/@f-design/component-library)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ If talking to a real person is your jam, reach out to the `#questions` channel i
 - Find an issue of interest in the **"To Do"** column of the [Component Library project board](https://github.com/featherweight-design/component-library/projects/1)
 - To have this issue assigned to you, leave a comment on the issue itself or post in the `#component-library` Slack channel (an admin must approve your request)
 - Once approved, move your issue to the **"In Progress"** column of the project board
-- Pull down the latest changes from `development` and checkout a new branch prefaced with your first name (e.g. `hugh/icon-component`)
+- Pull down the latest changes from `development` and checkout a new branch prefaced with your first name (e.g. `hugh-icon-component`)
 
 ### During Development
 

--- a/src/components/Buttons/ActionButton/ActionButton.stories.mdx
+++ b/src/components/Buttons/ActionButton/ActionButton.stories.mdx
@@ -12,7 +12,7 @@ import ActionButton from './ActionButton.tsx';
 
 ---
 
-The `ActionButton` component is a more mobile friendly button with a larger footprint than the `Button` component. Its primary use case is for specific call to actions (e.g. "complete", "cancel", "add", etc.).
+The `ActionButton` component is a more mobile friendly button with a larger footprint than the `Button` component. Its primary use case is for specific call to actions (e.g. "complete", "cancel", "add", etc.). It can render three types of values, each with greater priority in decending order: `children`, `image`, and `icon`.
 
 ## Quick Start ⚡️
 

--- a/src/components/Buttons/ActionButton/ActionButton.stories.tsx
+++ b/src/components/Buttons/ActionButton/ActionButton.stories.tsx
@@ -239,11 +239,37 @@ export const VariantsWithSizes = (): JSX.Element => (
   </div>
 );
 
+export const withChildren = (): JSX.Element => (
+  <ActionButton onClick={mockClick}>
+    <div style={{ display: 'grid', gap: '0.25rem' }}>
+      <span
+        style={{
+          width: '1.5rem',
+          height: '0.125rem',
+          borderRadius: '1px',
+          backgroundColor: 'white',
+        }}
+      />
+      <span
+        style={{
+          width: '1.125rem',
+          height: '0.125rem',
+          borderRadius: '1px',
+          backgroundColor: 'white',
+        }}
+      />
+      <span
+        style={{
+          width: '1.5rem',
+          height: '0.125rem',
+          borderRadius: '1px',
+          backgroundColor: 'white',
+        }}
+      />
+    </div>
+  </ActionButton>
+);
+
 export const WithImage = (): JSX.Element => (
-  <ActionButton
-    image={fwdLogo}
-    onClick={mockClick}
-    label="Conga"
-    variant="secondary"
-  />
+  <ActionButton image={fwdLogo} onClick={mockClick} />
 );

--- a/src/components/Buttons/ActionButton/ActionButton.tsx
+++ b/src/components/Buttons/ActionButton/ActionButton.tsx
@@ -30,6 +30,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   variant = DEFAULT_VARIANT,
   shape = DEFAULT_SHAPE,
   type,
+  children,
 }: ActionButtonProps): ReactElement => (
   <div
     id={id}
@@ -52,7 +53,7 @@ const ActionButton: FC<ActionButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       style={
-        image
+        !children && image
           ? {
               backgroundImage: `url(${image})`,
               backgroundSize: 'cover',
@@ -66,13 +67,14 @@ const ActionButton: FC<ActionButtonProps> = ({
         </div>
       )}
 
-      {!loading && icon && (
+      {!loading && !image && !children && icon && (
         <Icon
           className="fd-action-button__icon"
           icon={icon}
           size={SIZES_ENUM[size]}
         />
       )}
+      {children}
     </button>
 
     {label && <p className="fd-action-button__label">{label}</p>}

--- a/src/components/Buttons/Button/Button.stories.tsx
+++ b/src/components/Buttons/Button/Button.stories.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState, ChangeEvent } from 'react';
 import { withA11y } from '@storybook/addon-a11y';
 
 import Button from './Button';
+import Input from '../../Input/Input';
 
 export default {
   title: 'Components/Buttons/Button',
@@ -15,6 +16,61 @@ export const Default = (): JSX.Element => (
     Click Me!
   </Button>
 );
+
+export const Playground = (): JSX.Element => {
+  const [color, updateColorValue] = useState('#000');
+  const [backgroundColor, updateBackgroundColorValue] = useState('#F56C70');
+  const [borderColor, updateBorderColor] = useState('#00FFE5');
+
+  return (
+    <div className="container">
+      <div className="story__controls-container">
+        <Input
+          label="Brand color"
+          name="brand-color"
+          value={color}
+          onChange={({
+            target: { value },
+          }: ChangeEvent<HTMLInputElement>): void => updateColorValue(value)}
+        />
+
+        <Input
+          label="Brand background color"
+          name="brand-background-color"
+          value={backgroundColor}
+          onChange={({
+            target: { value },
+          }: ChangeEvent<HTMLInputElement>): void =>
+            updateBackgroundColorValue(value)
+          }
+        />
+
+        <Input
+          label="Outline border color"
+          name="outline-border-color"
+          value={borderColor}
+          onChange={({
+            target: { value },
+          }: ChangeEvent<HTMLInputElement>): void => updateBorderColor(value)}
+        />
+      </div>
+
+      <div className="story__button-container">
+        <Button
+          onClick={mockClick}
+          variant="brand"
+          style={{ backgroundColor, color }}
+        >
+          Brand
+        </Button>
+
+        <Button onClick={mockClick} variant="outline" style={{ borderColor }}>
+          Outline
+        </Button>
+      </div>
+    </div>
+  );
+};
 
 export const Shapes = (): JSX.Element => (
   <div className="story__button-container">

--- a/src/components/Buttons/Button/Button.tsx
+++ b/src/components/Buttons/Button/Button.tsx
@@ -16,6 +16,7 @@ const Button: FC<ButtonProps> = ({
   disabled,
   loading,
   type,
+  style,
   shape = DEFAULT_SHAPE,
 }: ButtonProps) => (
   <button
@@ -24,6 +25,7 @@ const Button: FC<ButtonProps> = ({
     type={type}
     onClick={onClick}
     disabled={disabled}
+    style={style}
     className={classnames({
       'fd-button': true,
       [`fd-button-${variant}`]: variant,

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -13,7 +13,7 @@
   background: none;
   color: $brand-color;
   cursor: pointer;
-  transition: 0.1s ease-in-out;
+  transition: 0.2s ease-in-out;
   &:hover:not(.fd-button-loading):not(:disabled) {
     color: $brand-hover;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 import { ChangeEvent, ReactChild } from 'react';
 
+type Children = ReactChild | ReactChild[];
+
 //* Accordion Types
 export interface AccordionProps {
-  children: ReactChild | ReactChild[];
+  children: Children;
   /**
    * Applied to parent container
    */
@@ -54,16 +56,17 @@ export interface ActionButtonProps {
    */
   shape?: ButtonShape;
   type?: ButtonType;
+  children?: Children;
 }
 
 export type ActionButtonShape = 'round' | 'rounded-square' | 'square';
 
 export type ActionButtonSize =
-  | 'x-small'
-  | 'small'
-  | 'medium'
-  | 'large'
-  | 'x-large';
+  | 'x-small' // 36px
+  | 'small' // 42px
+  | 'medium' // 28px
+  | 'large' // 54px
+  | 'x-large'; // 60px
 
 export type ActionButtonVariant = 'primary' | 'secondary' | 'glass';
 
@@ -72,7 +75,7 @@ export interface ButtonProps {
   /**
    * Value of the button
    */
-  children: string | number | ReactChild | ReactChild[];
+  children: string | number | Children;
   onClick: () => void;
   id?: string;
   variant?: ButtonVariant;
@@ -189,7 +192,7 @@ export type ProgressBarSizes =
 
 //* Reveal Types
 export interface RevealProps {
-  children: ReactChild | ReactChild[];
+  children: Children;
   isShown: boolean;
   /**
    * Applied to the `div` container

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,11 +88,21 @@ export interface ButtonProps {
    */
   shape?: ButtonShape;
   type?: ButtonType;
+  /**
+   * Style overrides for backgroundColor, borderColor, and color
+   */
+  style?: ButtonStyles;
 }
 
 export type ButtonType = 'submit' | 'reset' | 'button';
 
 export type ButtonShape = 'round' | 'rounded-square' | 'square';
+
+export interface ButtonStyles {
+  backgroundColor?: string;
+  borderColor?: string;
+  color?: string;
+}
 
 export type ButtonVariant =
   | 'default-destructive'


### PR DESCRIPTION
## Description

- Release version: [0.1.58](https://www.npmjs.com/package/@f-design/component-library)
- Issues:
  - Resolves #53 #54 

## Changes

- Adds `children` prop to `ActionButton` with documentation and examples
- Adds `style` prop to `Button` for `color/background-color/border-color` overrides with documentation and examples

## Fixes

- Fixes typo in `CONTRIBUTING` and stale content in GH issue/PR templates

## Screenshots

![image](https://user-images.githubusercontent.com/24458700/104115594-1ab8ee80-52ce-11eb-93c9-85f4ae8da7cf.png)
![image](https://user-images.githubusercontent.com/24458700/104115604-273d4700-52ce-11eb-864e-b21693c03674.png)


## Sanity Checks

- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
- [x] There are no incidental style changes