### PR TITLE
Hugh headermenu tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 ## Description
 
+<BRIEF_DESCRIPTION>
+
 - Issues:
   - Resolves #<ISSUE_NUMBER>
-
-<BRIEF_DESCRIPTION>
 
 ## Changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,4 @@
 
 ## Sanity Checks
 
-- [ ] All tests are passing
-- [ ] There are no linting errors
-- [ ] There are no build errors
 - [ ] There are no incidental style changes

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         # Each test suite should be listed here for running parallel tests
-        test-suite: ["ActionButton", "Button", "Input"]
+        test-suite: ["ActionButton", "Button", "Input", "HeaderMenu"]
         # Multiple machines are used for load balancing
         machines: [1, 2, 3, 4, 5, 6]
     steps:

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -61,7 +61,6 @@ const Accordion: FC<AccordionProps> = ({
               'fd-accordion__icon-hidden': !isExpanded,
             })}
             icon="keyboard_arrow_down"
-            size="0.875rem"
           />
           <span className="fd-accordion__title">{title}</span>
         </button>

--- a/src/components/Buttons/ActionButton/ActionButton.tsx
+++ b/src/components/Buttons/ActionButton/ActionButton.tsx
@@ -55,14 +55,11 @@ const ActionButton: FC<ActionButtonProps> = ({
       })}
       onClick={onClick}
       disabled={disabled}
-      style={
-        !children && image
-          ? {
-              backgroundImage: `url(${image})`,
-              backgroundSize: 'cover',
-            }
-          : {}
-      }
+      style={{
+        fontSize: SIZES_ENUM[size],
+        backgroundImage: image ? `url(${image})` : 'unset',
+        backgroundSize: image ? `cover` : 'unset',
+      }}
     >
       {loading && (
         <div className="fd-action-button__loader-container">
@@ -71,11 +68,7 @@ const ActionButton: FC<ActionButtonProps> = ({
       )}
 
       {!loading && !image && !children && icon && (
-        <Icon
-          className="fd-action-button__icon"
-          icon={icon}
-          size={SIZES_ENUM[size]}
-        />
+        <Icon className="fd-action-button__icon" icon={icon} />
       )}
       {children}
     </button>

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -12,7 +12,3 @@ export const Default = (): JSX.Element => <Icon icon="search" />;
 export const WithCustomColor = (): JSX.Element => (
   <Icon icon="search" color="red" />
 );
-
-export const WithCustomSize = (): JSX.Element => (
-  <Icon icon="search" size="4rem" color="teal" />
-);

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -8,7 +8,3 @@ export default {
 };
 
 export const Default = (): JSX.Element => <Icon icon="search" />;
-
-export const WithCustomColor = (): JSX.Element => (
-  <Icon icon="search" color="red" />
-);

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 
 import { IconProps } from 'types';
 
-const Icon: FC<IconProps> = ({ className, color, icon, id }: IconProps) => (
+const Icon: FC<IconProps> = ({ className, icon, id }: IconProps) => (
   <i
     id={id}
     className={classnames({
@@ -11,17 +11,9 @@ const Icon: FC<IconProps> = ({ className, color, icon, id }: IconProps) => (
       'fd-icon': true,
       [className as string]: className,
     })}
-    style={{
-      color,
-    }}
   >
     {icon}
   </i>
 );
-
-Icon.defaultProps = {
-  className: '',
-  color: 'currentColor',
-};
 
 export default Icon;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,14 +3,7 @@ import classnames from 'classnames';
 
 import { IconProps } from 'types';
 
-const Icon: FC<IconProps> = ({
-  className,
-  size,
-  color,
-  icon,
-  id,
-  dataId,
-}: IconProps) => (
+const Icon: FC<IconProps> = ({ className, color, icon, id }: IconProps) => (
   <i
     id={id}
     className={classnames({
@@ -18,9 +11,7 @@ const Icon: FC<IconProps> = ({
       'fd-icon': true,
       [className as string]: className,
     })}
-    data-id={dataId}
     style={{
-      fontSize: size,
       color,
     }}
   >
@@ -30,7 +21,6 @@ const Icon: FC<IconProps> = ({
 
 Icon.defaultProps = {
   className: '',
-  size: '24px',
   color: 'currentColor',
 };
 

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
@@ -1,29 +1,38 @@
 import { withA11y } from '@storybook/addon-a11y';
 
+import { headerMenuCopy } from 'shared/data/copyContent';
 import HeaderMenu from './HeaderMenu';
+
+const {
+  defaultSubTitle,
+  defaultTitle,
+  icons,
+  subOptionLabels,
+  userName,
+} = headerMenuCopy;
 
 const subOptions = [
   {
-    icon: 'group',
-    label: 'User Management',
+    icon: icons.userManagement,
+    label: subOptionLabels.userManagement,
     path: '/user-management',
     hasAccess: true,
   },
   {
-    icon: 'account_tree',
-    label: 'Permissions',
+    icon: icons.permissions,
+    label: subOptionLabels.permissions,
     path: '/permissions',
     hasAccess: true,
   },
   {
-    icon: 'mail',
-    label: 'Support',
+    icon: icons.support,
+    label: subOptionLabels.support,
     path: '/support',
     hasAccess: true,
   },
   {
-    icon: 'info',
-    label: 'Info',
+    icon: icons.info,
+    label: subOptionLabels.info,
     path: '/info',
     hasAccess: true,
   },
@@ -37,21 +46,21 @@ export default {
 export const Default = (): JSX.Element => (
   <HeaderMenu
     currentlyViewing={{
-      title: 'Best Site',
-      subTitle: 'ever',
+      title: defaultTitle,
+      subTitle: defaultSubTitle,
       path: '/best-site',
     }}
     menuOptions={{
       settings: {
-        icon: 'settings',
+        icon: icons.settings,
         path: '/settings',
       },
       notifications: {
-        icon: 'notifications',
+        icon: icons.notifications,
         path: '/notifications',
       },
       search: {
-        icon: 'search',
+        icon: icons.search,
       },
     }}
   />
@@ -61,13 +70,13 @@ export const WithDarkTheme = (): JSX.Element => (
   <HeaderMenu
     goDark
     currentlyViewing={{
-      title: 'Permissions',
+      title: subOptionLabels.permissions,
       path: '/permissions',
     }}
     menuOptions={{
       settings: {
-        subTitle: 'Bob H.',
-        icon: 'settings',
+        subTitle: userName,
+        icon: icons.settings,
         subOptions,
       },
     }}
@@ -77,18 +86,18 @@ export const WithDarkTheme = (): JSX.Element => (
 export const WithIndicator = (): JSX.Element => (
   <HeaderMenu
     currentlyViewing={{
-      title: 'Notifications',
+      title: subOptionLabels.notifications,
       path: '/notifications',
     }}
     menuOptions={{
       notifications: {
-        icon: 'notifications',
+        icon: icons.notifications,
         path: '/notifications',
         indicator: true,
         isActive: true,
       },
       search: {
-        icon: 'search',
+        icon: icons.search,
       },
     }}
   />
@@ -101,8 +110,8 @@ export const WithoutTitle = (): JSX.Element => (
     }}
     menuOptions={{
       settings: {
-        subTitle: 'Bob H.',
-        icon: 'settings',
+        subTitle: userName,
+        icon: icons.settings,
         subOptions,
       },
     }}
@@ -112,13 +121,13 @@ export const WithoutTitle = (): JSX.Element => (
 export const WithSubOptions = (): JSX.Element => (
   <HeaderMenu
     currentlyViewing={{
-      title: 'Permissions',
+      title: subOptionLabels.permissions,
       path: '/permissions',
     }}
     menuOptions={{
       settings: {
         subTitle: 'Bob H.',
-        icon: 'settings',
+        icon: icons.settings,
         subOptions,
       },
     }}

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.stories.tsx
@@ -121,11 +121,12 @@ export const WithoutTitle = (): JSX.Element => (
 export const WithSubOptions = (): JSX.Element => (
   <HeaderMenu
     currentlyViewing={{
-      title: subOptionLabels.permissions,
-      path: '/permissions',
+      title: defaultTitle,
+      subTitle: defaultSubTitle,
+      path: '/best-site',
     }}
     menuOptions={{
-      settings: {
+      menu: {
         subTitle: 'Bob H.',
         icon: icons.settings,
         subOptions,

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -254,6 +254,7 @@ const HeaderMenu: FC<HeaderMenuProps> = ({
                     [`${baseClassName}__sub-options-shown`]: isSelected,
                   })}
                   ref={subOptionsMenu}
+                  role="menu"
                 >
                   <div className={`${baseClassName}__sub-options-header`}>
                     <span className={`${baseClassName}__sub-options-title`}>
@@ -285,6 +286,7 @@ const HeaderMenu: FC<HeaderMenuProps> = ({
         [`${baseClassName}`]: true,
         [className as string]: className,
       })}
+      role="menubar"
     >
       <div className={`${baseClassName}__left`}>
         <div className={`${baseClassName}__location-container`}>

--- a/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/Navigation/HeaderMenu/HeaderMenu.tsx
@@ -242,7 +242,7 @@ const HeaderMenu: FC<HeaderMenuProps> = ({
               {indicator && (
                 <div
                   className={`${baseClassName}__icon-indicator`}
-                  role="menuitem"
+                  role="alert"
                 >
                   {typeof indicator === 'number' && indicator}
                 </div>

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -36,7 +36,7 @@ const ProgressBar: FC<ProgressBarProps> = ({
         [className as string]: className,
       })}
     >
-      <div className="fd-progress-bar__progress-container">
+      <div className="fd-progress-bar__progress-container" style={{ color }}>
         <div
           className={classnames({
             'fd-progress-bar__fill-container': true,
@@ -66,8 +66,6 @@ const ProgressBar: FC<ProgressBarProps> = ({
               'fd-progress-bar__completion-icon-hidden': !areAllItemsComplete,
             })}
             icon="check_circle"
-            color={color}
-            size="1rem"
           />
         )}
       </div>

--- a/src/cypress/integration/Navigation/HeaderMenu/header-menu-default.spec.ts
+++ b/src/cypress/integration/Navigation/HeaderMenu/header-menu-default.spec.ts
@@ -1,0 +1,28 @@
+import { headerMenuCopy } from 'shared/data/copyContent';
+
+describe('HeaderMenu default tests', () => {
+  before(() => {
+    cy.visitStorybook();
+    cy.loadStory('components-navigation-headermenu', 'default');
+  });
+
+  it('Should have a title', () => {
+    cy.findByText(headerMenuCopy.defaultTitle);
+  });
+
+  it('Should have a sub-title', () => {
+    cy.findByText(headerMenuCopy.defaultSubTitle);
+  });
+
+  it('Should have a settings option', () => {
+    cy.findByText(headerMenuCopy.icons.settings);
+  });
+
+  it('Should have a notifications option', () => {
+    cy.findByText(headerMenuCopy.icons.notifications);
+  });
+
+  it('Should have a search option', () => {
+    cy.findByText(headerMenuCopy.icons.search);
+  });
+});

--- a/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-indicator.spec.ts
+++ b/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-indicator.spec.ts
@@ -1,0 +1,16 @@
+import { headerMenuCopy } from 'shared/data/copyContent';
+
+describe('HeaderMenu with indicator tests', () => {
+  before(() => {
+    cy.visitStorybook();
+    cy.loadStory('components-navigation-headermenu', 'with-indicator');
+  });
+
+  it('Should have a notifications icon', () => {
+    cy.findByText(headerMenuCopy.icons.notifications);
+  });
+
+  it('Should have a notifications indicator', () => {
+    cy.findByRole('alert');
+  });
+});

--- a/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-indicator.spec.ts
+++ b/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-indicator.spec.ts
@@ -1,6 +1,6 @@
 import { headerMenuCopy } from 'shared/data/copyContent';
 
-describe('HeaderMenu with indicator tests', () => {
+describe('HeaderMenu with Indicator tests', () => {
   before(() => {
     cy.visitStorybook();
     cy.loadStory('components-navigation-headermenu', 'with-indicator');

--- a/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-sub-options.spec.ts
+++ b/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-sub-options.spec.ts
@@ -1,0 +1,52 @@
+import { headerMenuCopy } from 'shared/data/copyContent';
+
+describe('HeaderMenu with Sub Options tests', () => {
+  before(() => {
+    cy.visitStorybook();
+    cy.loadStory('components-navigation-headermenu', 'with-sub-options');
+  });
+
+  it('Should have a settings icon', () => {
+    cy.findByText(headerMenuCopy.icons.settings);
+  });
+
+  it('Should open a menu when the settings icon is clicked', () => {
+    cy.findByText(headerMenuCopy.icons.settings).click();
+    cy.findByRole('menu');
+  });
+
+  it('Should have a title in the menu', () => {
+    cy.findByText(headerMenuCopy.menuTitle);
+  });
+
+  it('Should have a user name in the menu', () => {
+    cy.findByText(headerMenuCopy.userName);
+  });
+
+  it('Should have four menu items in the menu', () => {
+    cy.findByText(headerMenuCopy.subOptionLabels.userManagement);
+    cy.findByText(headerMenuCopy.subOptionLabels.permissions);
+    cy.findByText(headerMenuCopy.subOptionLabels.support);
+    cy.findAllByText(headerMenuCopy.subOptionLabels.info).last();
+  });
+
+  it('Should close the menu when clicking the settings icon', () => {
+    cy.findByText(headerMenuCopy.icons.settings).click();
+    cy.findByRole('menu').should('not.be.visible');
+  });
+
+  it('Should close the menu when clicking off the menu', () => {
+    cy.findByText(headerMenuCopy.icons.settings).click();
+    cy.findByRole('menubar').click();
+    cy.findByRole('menu').should('not.be.visible');
+  });
+
+  it('Should close the menu when selecting an option', () => {
+    cy.findByText(headerMenuCopy.icons.settings).click();
+    // Test fails when clicking the text, so target the actual menu item
+    cy.findByText(headerMenuCopy.subOptionLabels.userManagement)
+      .closest('div[role="link"]')
+      .click();
+    cy.findByRole('menu').should('not.be.visible');
+  });
+});

--- a/src/cypress/integration/Navigation/HeaderMenu/header-menu-without-title.spec.ts
+++ b/src/cypress/integration/Navigation/HeaderMenu/header-menu-without-title.spec.ts
@@ -1,6 +1,6 @@
 import { headerMenuCopy } from 'shared/data/copyContent';
 
-describe('HeaderMenu default tests', () => {
+describe('HeaderMenu without Title tests', () => {
   before(() => {
     cy.visitStorybook();
     cy.loadStory('components-navigation-headermenu', 'without-title');

--- a/src/cypress/integration/Navigation/HeaderMenu/header-menu-without-title.spec.ts
+++ b/src/cypress/integration/Navigation/HeaderMenu/header-menu-without-title.spec.ts
@@ -1,0 +1,12 @@
+import { headerMenuCopy } from 'shared/data/copyContent';
+
+describe('HeaderMenu default tests', () => {
+  before(() => {
+    cy.visitStorybook();
+    cy.loadStory('components-navigation-headermenu', 'without-title');
+  });
+
+  it('Should not have a title', () => {
+    cy.findByText(headerMenuCopy.defaultTitle).should('not.exist');
+  });
+});

--- a/src/shared/data/copyContent/headerMenuCopy.ts
+++ b/src/shared/data/copyContent/headerMenuCopy.ts
@@ -1,0 +1,20 @@
+export default {
+  defaultTitle: 'Best Site',
+  defaultSubTitle: 'ever',
+  icons: {
+    info: 'info',
+    notifications: 'notifications',
+    permissions: 'account_tree',
+    search: 'search',
+    settings: 'settings',
+    support: 'mail',
+    userManagement: 'group',
+  },
+  subOptions: {
+    infoLabel: 'Info',
+    permissionsLabel: 'Permissions',
+    supportLabel: 'Support',
+    userManagementLabel: 'User Management',
+  },
+  userName: 'Bob H.',
+};

--- a/src/shared/data/copyContent/headerMenuCopy.ts
+++ b/src/shared/data/copyContent/headerMenuCopy.ts
@@ -10,12 +10,13 @@ export default {
     support: 'mail',
     userManagement: 'group',
   },
+  menuTitle: 'menu',
   subOptionLabels: {
-    info: 'Info',
-    notifications: 'Notifications',
-    permissions: 'Permissions',
-    support: 'Support',
-    userManagement: 'User Management',
+    info: 'info',
+    notifications: 'notifications',
+    permissions: 'permissions',
+    support: 'support',
+    userManagement: 'user management',
   },
   userName: 'Bob H.',
 };

--- a/src/shared/data/copyContent/headerMenuCopy.ts
+++ b/src/shared/data/copyContent/headerMenuCopy.ts
@@ -1,6 +1,6 @@
 export default {
-  defaultTitle: 'Best Site',
   defaultSubTitle: 'ever',
+  defaultTitle: 'Best Site',
   icons: {
     info: 'info',
     notifications: 'notifications',
@@ -10,11 +10,12 @@ export default {
     support: 'mail',
     userManagement: 'group',
   },
-  subOptions: {
-    infoLabel: 'Info',
-    permissionsLabel: 'Permissions',
-    supportLabel: 'Support',
-    userManagementLabel: 'User Management',
+  subOptionLabels: {
+    info: 'Info',
+    notifications: 'Notifications',
+    permissions: 'Permissions',
+    support: 'Support',
+    userManagement: 'User Management',
   },
   userName: 'Bob H.',
 };

--- a/src/shared/data/copyContent/index.ts
+++ b/src/shared/data/copyContent/index.ts
@@ -1,5 +1,6 @@
 import actionButtonCopy from './actionButtonCopy';
 import buttonCopy from './buttonCopy';
+import headerMenuCopy from './headerMenuCopy';
 import inputCopy from './inputCopy';
 
-export { actionButtonCopy, buttonCopy, inputCopy };
+export { actionButtonCopy, buttonCopy, headerMenuCopy, inputCopy };

--- a/src/styles/components/Accordion.scss
+++ b/src/styles/components/Accordion.scss
@@ -22,6 +22,7 @@
     color: $cool-gray-19;
     background-color: $gray-02;
     box-shadow: $brand-color 0.25rem 0 0 inset;
+    font-size: 1rem;
     transition: box-shadow 0.2s ease-in-out;
     &:focus {
       outline: none;
@@ -36,9 +37,6 @@
     &-hidden {
       transform: rotate(-90deg);
     }
-  }
-  &__title {
-    font-size: 1rem;
   }
   &__content {
     position: relative;

--- a/src/styles/components/HeaderMenu.scss
+++ b/src/styles/components/HeaderMenu.scss
@@ -42,6 +42,13 @@
   &__icon-container {
     position: relative;
     margin-left: 1.5rem;
+    &:focus {
+      outline: none;
+      > .fd-header-menu__menu-icon-background,
+      .fd-header-menu-dark__menu-icon-background {
+        @include focus-styles;
+      }
+    }
   }
   &__menu-icon-background {
     position: absolute;
@@ -187,7 +194,7 @@
       opacity: 1;
     }
     &:focus {
-      outline: none;
+      @include focus-styles;
     }
     &:last-child {
       padding-bottom: 1.5rem;

--- a/src/styles/components/Icon.scss
+++ b/src/styles/components/Icon.scss
@@ -1,0 +1,6 @@
+@import '../variables';
+@import '../mixins';
+
+.fd-icon {
+  font-size: inherit;
+}

--- a/src/styles/components/ProgressBar.scss
+++ b/src/styles/components/ProgressBar.scss
@@ -15,6 +15,7 @@
     width: 100%;
     border-radius: 1px;
     background-color: $gray-05;
+    font-size: 1rem;
     transition: background-color 0.2s ease-in-out;
     &-rounded {
       border-radius: 0.25rem;

--- a/src/styles/components/all.scss
+++ b/src/styles/components/all.scss
@@ -5,6 +5,7 @@
 @import './CircleLoader';
 @import './Errors.scss';
 @import './HeaderMenu';
+@import './Icon';
 @import './Input';
 @import './Label.scss';
 @import './OtherOption';

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,9 +172,7 @@ export interface IconProps {
   icon: string;
   className?: string;
   color?: string;
-  dataId?: string;
   id?: string;
-  size?: string;
 }
 
 export interface IconArgsType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,7 +178,6 @@ export interface IconProps {
 export interface IconArgsType {
   icon: string;
   className?: string;
-  color?: string;
 }
 
 //* Input Types


### PR DESCRIPTION
## Description

Writes all tests for `HeaderMenu` and does some light refactoring to improve accessibility and intra-component use.

- Issues:
  - Resolves #83 

## Changes

- **`BREAKING CHANGE`**: Removes `size/color` props from the `Icon` component to allow for `font-size/color` inheritance via CSS (Updates `Icon` stories accordingly)
- Writes all `HeaderMenu` Cypress tests
- Refactors `HeaderMenu` stories to use a copy content data object plus additional tweaks for easier testing
- Updates PR template

**`HeaderMenu`**
- Implements necessary HTML `role`s where necessary to improve accessibility
- Migrates menu item click events from the `Icon` to the outer container
- Removes click/keyboard events from the menu item `indicator`
- Replaces all `i` elements with `Icon` components
- Updates `handleHeaderMenuOutsideClick` to fire when selecting a menu item
- Updates focus styling for menu and sub-option items

## Fixes

- Fixes race condition of click events which prevented any `HeaderMenu` sub-option menus from displaying
- Fixes keyboard interactions in `HeaderMenu` to properly trigger on specific `key`s by using the `keyboardEventEnum`

## Sanity Checks

- [x] There are no incidental style changes