### PR TITLE
Hugh input minimal variant

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -140,7 +140,7 @@ jobs:
           group: "${{ matrix.test-suite }} Tests"
           spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
           browser: chrome
-          start: yarn storybook
+          start: yarn storybook --ci
           record: true
           parallel: true
           # tag will be either "push" or "pull_request"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-
 
       # we use the exact restore key to avoid Cypress binary snowballing
       # https://glebbahmutov.com/blog/do-not-let-cypress-cache-snowball/
@@ -44,18 +44,18 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
           restore-keys: |
-            cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+            cypress-${{ runner.os }}-cypress-
 
       # Cache local node_modules to pass to testing jobs
       - name: Cache local node_modules
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-${{ github.ref }}-
+            ${{ runner.os }}-node-modules-
 
       - name: Install dependencies and verify Cypress
         env:
@@ -84,9 +84,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-${{ github.ref }}-
+            ${{ runner.os }}-node-modules-
 
       # Runs actions specific script that does not fix errors
       - name: Check linting
@@ -116,17 +116,17 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
           restore-keys: |
-            cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+            cypress-${{ runner.os }}-cypress-
 
       - name: Cache local node_modules
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-${{ github.ref }}-
+            ${{ runner.os }}-node-modules-
 
       # check the restored Cypress binary
       - name: Check binary
@@ -174,9 +174,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-${{ github.ref }}-
+            ${{ runner.os }}-node-modules-
 
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@v1

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@
 /storybook-dist
 
 # cypress artifacts
-/cypress/videos
-/cypress/screenshots
+videos
+screenshots
 
 # misc
 /notes

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   stories: [
-    '../src/components/**/*.stories.(tsx|mdx)',
+    '../src/components/**/*.stories.@(tsx|mdx)',
     '../docs/**/*.stories.mdx',
   ],
   addons: [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release": "standard-version -t @f-design/component-library@",
     "release-beta": "standard-version --prerelease beta --skip.changelog --skip.tag",
     "release-canary": "standard-version --prerelease canary-$PR_DEV-$UUID --skip.changelog --skip.tag",
-    "storybook": "start-storybook -p 6006 -s ./.storybook/public/",
+    "storybook": "start-storybook --quiet -p 6006 -s ./.storybook/public/",
     "storybook-build": "build-storybook -s ./.storybook/public/ -o ./storybook-dist",
     "storybook-smoke-test": "start-storybook --smoke-test",
     "test": "jest --config jestconfig.json",

--- a/src/components/Form/Input/Input.stories.tsx
+++ b/src/components/Form/Input/Input.stories.tsx
@@ -21,7 +21,7 @@ export const Default = (): JSX.Element => {
       <Input
         value={inputValue}
         name="default"
-        label={inputCopy.label}
+        label={inputCopy.textLabel}
         onChange={mockOnChange}
       />
     </div>
@@ -30,22 +30,35 @@ export const Default = (): JSX.Element => {
 
 export const Types = (): JSX.Element => {
   const [defaultValue, handleChangeTextValue] = useState('');
-  const [percentage, handleChangePercentage] = useState('');
+  const [numberValue, handleChangePercentage] = useState('');
   const [errorValue, handleChangeErrorValue] = useState('');
+  const [passwordValue, handleChangePasswordValue] = useState('');
+
+  const inputNames = {
+    default: 'default',
+    disabled: 'disabled',
+    error: 'error',
+    number: 'number',
+    password: 'password',
+  };
 
   const mockOnChange = ({
     target: { value, name },
   }: ChangeEvent<HTMLInputElement>): void => {
-    if (name === 'default') {
+    if (name === inputNames.default) {
       handleChangeTextValue(value);
     }
 
-    if (name === 'number') {
+    if (name === inputNames.number) {
       handleChangePercentage(value);
     }
 
-    if (name === 'errorValue') {
+    if (name === inputNames.error) {
       handleChangeErrorValue(value);
+    }
+
+    if (name === inputNames.password) {
+      handleChangePasswordValue(value);
     }
   };
 
@@ -53,14 +66,14 @@ export const Types = (): JSX.Element => {
     <div className="story__input-container">
       <Input
         value={defaultValue}
-        name="default"
+        name={inputNames.default}
         label={inputCopy.textLabel}
         onChange={mockOnChange}
       />
 
       <Input
-        value={percentage}
-        name="number"
+        value={numberValue}
+        name={inputNames.number}
         type="number"
         label={inputCopy.numberLabel}
         placeholder={inputCopy.numberPlaceholder}
@@ -71,7 +84,7 @@ export const Types = (): JSX.Element => {
 
       <Input
         value=""
-        name="disabled"
+        name={inputNames.disabled}
         label={inputCopy.disabledLabel}
         onChange={mockOnChange}
         disabled
@@ -79,9 +92,17 @@ export const Types = (): JSX.Element => {
 
       <Input
         value={errorValue}
-        name="errorValue"
+        name={inputNames.error}
         label={inputCopy.errorLabel}
         errorMessage={errorValue ? '' : inputCopy.errorMessage}
+        onChange={mockOnChange}
+      />
+
+      <Input
+        value={passwordValue}
+        name={inputNames.password}
+        type="password"
+        label={inputCopy.passwordLabel}
         onChange={mockOnChange}
       />
     </div>

--- a/src/components/Form/Input/Input.stories.tsx
+++ b/src/components/Form/Input/Input.stories.tsx
@@ -4,6 +4,10 @@ import { withA11y } from '@storybook/addon-a11y';
 import { inputCopy } from 'shared/data/copyContent';
 import Input from './Input';
 
+interface InputChangeHandlers {
+  [key: string]: (value: string) => void;
+}
+
 export default {
   title: 'Components/Form/Input',
   decorators: [withA11y],
@@ -30,36 +34,34 @@ export const Default = (): JSX.Element => {
 
 export const Types = (): JSX.Element => {
   const [defaultValue, handleChangeTextValue] = useState('');
-  const [numberValue, handleChangePercentage] = useState('');
+  const [numberValue, handleChangeNumberValue] = useState('');
   const [errorValue, handleChangeErrorValue] = useState('');
   const [passwordValue, handleChangePasswordValue] = useState('');
+  const [minimalValue, handleChangeMinimalValue] = useState('');
 
   const inputNames = {
     default: 'default',
     disabled: 'disabled',
     error: 'error',
+    minimal: 'minimal',
     number: 'number',
     password: 'password',
+  };
+
+  const inputChangeHandlers: InputChangeHandlers = {
+    default: handleChangeTextValue,
+    error: handleChangeErrorValue,
+    minimal: handleChangeMinimalValue,
+    number: handleChangeNumberValue,
+    password: handleChangePasswordValue,
   };
 
   const mockOnChange = ({
     target: { value, name },
   }: ChangeEvent<HTMLInputElement>): void => {
-    if (name === inputNames.default) {
-      handleChangeTextValue(value);
-    }
+    const changeHandler = inputChangeHandlers[name as string];
 
-    if (name === inputNames.number) {
-      handleChangePercentage(value);
-    }
-
-    if (name === inputNames.error) {
-      handleChangeErrorValue(value);
-    }
-
-    if (name === inputNames.password) {
-      handleChangePasswordValue(value);
-    }
+    changeHandler(value);
   };
 
   return (
@@ -103,6 +105,14 @@ export const Types = (): JSX.Element => {
         name={inputNames.password}
         type="password"
         label={inputCopy.passwordLabel}
+        onChange={mockOnChange}
+      />
+
+      <Input
+        variant="minimal"
+        value={minimalValue}
+        name={inputNames.minimal}
+        label={inputCopy.minimalLabel}
         onChange={mockOnChange}
       />
     </div>

--- a/src/components/Form/Input/Input.tsx
+++ b/src/components/Form/Input/Input.tsx
@@ -48,7 +48,8 @@ const Input: FC<InputProps> = ({
         className={classnames({
           'fd-label': true,
           'fd-input__minimal-label': variant === MINIMAL_VARIANT,
-          'fd-input__minimal-label-top-aligned': isFocused || value,
+          'fd-input__minimal-label-top-aligned':
+            variant === MINIMAL_VARIANT && (isFocused || value),
         })}
       >
         {label}

--- a/src/components/Form/Input/Input.tsx
+++ b/src/components/Form/Input/Input.tsx
@@ -37,14 +37,10 @@ const Input: FC<InputProps> = ({
         [className as string]: className,
       })}
     >
-      {label && (
-        <label
-          htmlFor={id || `fd-input__${name}`}
-          className={classnames(['fd-label', 'fd-input__label'])}
-        >
-          {label}
-        </label>
-      )}
+      <label htmlFor={id || `fd-input__${name}`} className="fd-label">
+        {label}
+      </label>
+
       <input
         id={id || `fd-input__${name}`}
         name={name}

--- a/src/components/Form/Input/Input.tsx
+++ b/src/components/Form/Input/Input.tsx
@@ -1,10 +1,13 @@
 import { useState, FC } from 'react';
 import classnames from 'classnames';
 
-import Icon from 'components/Icon/Icon';
 import { InputProps } from 'types';
+import Icon from 'components/Icon/Icon';
+import { inputCopy } from 'shared/data/copyContent';
 
 const DEFAULT_INPUT_TYPE = 'text';
+const DEFAULT_INPUT_VARIANT = 'default';
+const MINIMAL_VARIANT = 'minimal';
 
 const Input: FC<InputProps> = ({
   name,
@@ -19,8 +22,10 @@ const Input: FC<InputProps> = ({
   disabled,
   className,
   errorMessage,
+  variant = DEFAULT_INPUT_VARIANT,
 }: InputProps) => {
   const [isPasswordShown, handleToggleShowPassword] = useState(false);
+  const [isFocused, handleToggleFocus] = useState(false);
 
   const getInputType = (): string => {
     if (type === 'password' && isPasswordShown) {
@@ -34,10 +39,18 @@ const Input: FC<InputProps> = ({
     <div
       className={classnames({
         'fd-input': true,
+        [`fd-input__${variant}`]: true,
         [className as string]: className,
       })}
     >
-      <label htmlFor={id || `fd-input__${name}`} className="fd-label">
+      <label
+        htmlFor={id || `fd-input__${name}`}
+        className={classnames({
+          'fd-label': true,
+          'fd-input__minimal-label': variant === MINIMAL_VARIANT,
+          'fd-input__minimal-label-top-aligned': isFocused || value,
+        })}
+      >
         {label}
       </label>
 
@@ -48,11 +61,14 @@ const Input: FC<InputProps> = ({
         type={getInputType()}
         placeholder={placeholder}
         onChange={onChange}
+        onBlur={(): void => handleToggleFocus(false)}
+        onFocus={(): void => handleToggleFocus(true)}
         min={min}
         max={max}
         disabled={disabled}
         className={classnames({
           'fd-input__input': true,
+          [`fd-input__${variant}-input`]: true,
           'fd-input__input-error': errorMessage,
         })}
       />
@@ -73,9 +89,9 @@ const Input: FC<InputProps> = ({
 };
 
 Input.defaultProps = {
-  id: '',
-  type: 'text',
-  placeholder: 'Enter a value...',
+  type: DEFAULT_INPUT_TYPE,
+  placeholder: inputCopy.placeholder,
+  variant: DEFAULT_INPUT_VARIANT,
 };
 
 export default Input;

--- a/src/components/Form/Input/Input.tsx
+++ b/src/components/Form/Input/Input.tsx
@@ -1,14 +1,17 @@
-import { FC } from 'react';
+import { useState, FC } from 'react';
 import classnames from 'classnames';
 
+import Icon from 'components/Icon/Icon';
 import { InputProps } from 'types';
+
+const DEFAULT_INPUT_TYPE = 'text';
 
 const Input: FC<InputProps> = ({
   name,
   value,
   onChange,
   id,
-  type,
+  type = DEFAULT_INPUT_TYPE,
   label,
   placeholder,
   min,
@@ -16,37 +19,62 @@ const Input: FC<InputProps> = ({
   disabled,
   className,
   errorMessage,
-}: InputProps) => (
-  <div
-    className={classnames({
-      'fd-input': true,
-      [className as string]: className,
-    })}
-  >
-    {label && (
-      <label htmlFor={id || `fd-input__${name}`} className="fd-label">
-        {label}
-      </label>
-    )}
-    <input
-      id={id || `fd-input__${name}`}
-      name={name}
-      value={value}
-      type={type}
-      placeholder={placeholder}
-      onChange={onChange}
-      min={min}
-      max={max}
-      disabled={disabled}
-      className={classnames({
-        'fd-input__input': true,
-        'fd-input__input-error': errorMessage,
-      })}
-    />
+}: InputProps) => {
+  const [isPasswordShown, handleToggleShowPassword] = useState(false);
 
-    <p className="fd-input-error">{errorMessage}</p>
-  </div>
-);
+  const getInputType = (): string => {
+    if (type === 'password' && isPasswordShown) {
+      return DEFAULT_INPUT_TYPE;
+    }
+
+    return type;
+  };
+
+  return (
+    <div
+      className={classnames({
+        'fd-input': true,
+        [className as string]: className,
+      })}
+    >
+      {label && (
+        <label
+          htmlFor={id || `fd-input__${name}`}
+          className={classnames(['fd-label', 'fd-input__label'])}
+        >
+          {label}
+        </label>
+      )}
+      <input
+        id={id || `fd-input__${name}`}
+        name={name}
+        value={value}
+        type={getInputType()}
+        placeholder={placeholder}
+        onChange={onChange}
+        min={min}
+        max={max}
+        disabled={disabled}
+        className={classnames({
+          'fd-input__input': true,
+          'fd-input__input-error': errorMessage,
+        })}
+      />
+
+      {type === 'password' && (
+        <button
+          className="fd-input__password-button"
+          type="button"
+          onClick={(): void => handleToggleShowPassword(!isPasswordShown)}
+        >
+          <Icon icon={isPasswordShown ? 'visibility_off' : 'visibility'} />
+        </button>
+      )}
+
+      <p className="fd-input-error">{errorMessage}</p>
+    </div>
+  );
+};
 
 Input.defaultProps = {
   id: '',

--- a/src/cypress/integration/Form/Input/input-types.spec.ts
+++ b/src/cypress/integration/Form/Input/input-types.spec.ts
@@ -121,4 +121,21 @@ describe('Input Types tests', () => {
       );
     });
   });
+
+  describe('Minimal tests', () => {
+    it('Should be displayed', () => {
+      cy.findByLabelText(inputCopy.minimalLabel);
+    });
+
+    it('Should accept a value', () => {
+      const expectedValue = 'stuff';
+
+      cy.findByLabelText(inputCopy.minimalLabel).type(expectedValue);
+
+      cy.findByLabelText(inputCopy.minimalLabel).should(
+        'have.value',
+        expectedValue
+      );
+    });
+  })
 });

--- a/src/cypress/integration/Form/Input/input-types.spec.ts
+++ b/src/cypress/integration/Form/Input/input-types.spec.ts
@@ -86,4 +86,39 @@ describe('Input Types tests', () => {
       cy.findByText(inputCopy.errorMessage).should('not.exist');
     });
   });
+
+  describe('Password input', () => {
+    let enteredValue: string;
+
+    beforeEach(() => {
+      enteredValue = 'password12345';
+    });
+
+    it('Should be displated', () => {
+      cy.findByLabelText(inputCopy.passwordLabel);
+    });
+
+    it('Should should hide the entered password value', () => {
+      cy.findByLabelText(inputCopy.passwordLabel).type(enteredValue);
+      cy.findByText(enteredValue).should('not.exist');
+    });
+
+    it('Should show the password value when clicking the show password button', () => {
+      cy.findByText(inputCopy.icons.showPassword).click();
+
+      cy.findByLabelText(inputCopy.passwordLabel).should(
+        'contain',
+        enteredValue
+      );
+    });
+
+    it('Should hide the password value when clicking the hide password button', () => {
+      cy.findByText(inputCopy.icons.hidePassword).click();
+
+      cy.findByLabelText(inputCopy.passwordLabel).should(
+        'not.contain',
+        enteredValue
+      );
+    });
+  });
 });

--- a/src/cypress/integration/Form/Input/input-types.spec.ts
+++ b/src/cypress/integration/Form/Input/input-types.spec.ts
@@ -105,20 +105,17 @@ describe('Input Types tests', () => {
 
     it('Should show the password value when clicking the show password button', () => {
       cy.findByText(inputCopy.icons.showPassword).click();
+      cy.findByText(inputCopy.icons.hidePassword).should('be.visible');
 
       cy.findByLabelText(inputCopy.passwordLabel).should(
-        'contain',
+        'have.value',
         enteredValue
       );
     });
 
     it('Should hide the password value when clicking the hide password button', () => {
       cy.findByText(inputCopy.icons.hidePassword).click();
-
-      cy.findByLabelText(inputCopy.passwordLabel).should(
-        'not.contain',
-        enteredValue
-      );
+      cy.findByText(inputCopy.icons.showPassword).should('be.visible');
     });
   });
 

--- a/src/cypress/integration/Form/Input/input-types.spec.ts
+++ b/src/cypress/integration/Form/Input/input-types.spec.ts
@@ -137,5 +137,5 @@ describe('Input Types tests', () => {
         expectedValue
       );
     });
-  })
+  });
 });

--- a/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-sub-options.spec.ts
+++ b/src/cypress/integration/Navigation/HeaderMenu/header-menu-with-sub-options.spec.ts
@@ -44,9 +44,7 @@ describe('HeaderMenu with Sub Options tests', () => {
   it('Should close the menu when selecting an option', () => {
     cy.findByText(headerMenuCopy.icons.settings).click();
     // Test fails when clicking the text, so target the actual menu item
-    cy.findByText(headerMenuCopy.subOptionLabels.userManagement)
-      .closest('div[role="link"]')
-      .click();
+    cy.findByText(headerMenuCopy.subOptionLabels.info).click();
     cy.findByRole('menu').should('not.be.visible');
   });
 });

--- a/src/shared/data/copyContent/headerMenuCopy.ts
+++ b/src/shared/data/copyContent/headerMenuCopy.ts
@@ -12,11 +12,11 @@ export default {
   },
   menuTitle: 'menu',
   subOptionLabels: {
-    info: 'info',
-    notifications: 'notifications',
-    permissions: 'permissions',
-    support: 'support',
-    userManagement: 'user management',
+    info: 'Info',
+    notifications: 'Notifications',
+    permissions: 'Permissions',
+    support: 'Support',
+    userManagement: 'User Management',
   },
   userName: 'Bob H.',
 };

--- a/src/shared/data/copyContent/inputCopy.ts
+++ b/src/shared/data/copyContent/inputCopy.ts
@@ -2,9 +2,10 @@ export default {
   disabledLabel: 'Disabled',
   errorLabel: 'Error',
   errorMessage: 'Please enter a value',
-  textLabel: 'Label',
+  minimalLabel: 'Minimal variant',
   numberLabel: 'Number',
   numberPlaceholder: '%',
   passwordLabel: 'Password',
   placeholder: 'Enter a value...',
+  textLabel: 'Label',
 };

--- a/src/shared/data/copyContent/inputCopy.ts
+++ b/src/shared/data/copyContent/inputCopy.ts
@@ -5,5 +5,6 @@ export default {
   textLabel: 'Label',
   numberLabel: 'Number',
   numberPlaceholder: '%',
+  passwordLabel: 'Password',
   placeholder: 'Enter a value...',
 };

--- a/src/shared/data/copyContent/inputCopy.ts
+++ b/src/shared/data/copyContent/inputCopy.ts
@@ -2,6 +2,10 @@ export default {
   disabledLabel: 'Disabled',
   errorLabel: 'Error',
   errorMessage: 'Please enter a value',
+  icons: {
+    showPassword: 'visibility',
+    hidePassword: 'visibility_off',
+  },
   minimalLabel: 'Minimal variant',
   numberLabel: 'Number',
   numberPlaceholder: '%',

--- a/src/styles/components/Icon.scss
+++ b/src/styles/components/Icon.scss
@@ -2,5 +2,5 @@
 @import '../mixins';
 
 .fd-icon {
-  font-size: inherit;
+  // font-size: inherit;
 }

--- a/src/styles/components/Input.scss
+++ b/src/styles/components/Input.scss
@@ -2,6 +2,7 @@
 @import '../mixins';
 
 .fd-input {
+  position: relative;
   display: flex;
   flex-direction: column;
   &__input {
@@ -18,6 +19,24 @@
     }
     &-error {
       border-color: $destructive;
+    }
+  }
+  &__password-button {
+    position:absolute;
+    top: 2rem;
+    right: 0.5rem;
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 0.25rem;
+    color: $gray-09;
+    background: none;
+    font-size: 1.25rem;
+    cursor: pointer;
+    &:focus {
+      @include focus-styles;
     }
   }
 }

--- a/src/styles/components/Input.scss
+++ b/src/styles/components/Input.scss
@@ -5,6 +5,18 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  &__minimal-label.fd-label {
+    position: absolute;
+    top: 2rem;
+    color: $brand-color-80;
+    font-size: 1rem;
+    transition: 0.2s ease-in-out;
+  }
+  &__minimal-label-top-aligned.fd-label {
+    top: 0;
+    font-size: 0.75rem;
+  }
+
   &__input {
     @include input-base-styles;
     &:disabled {
@@ -19,6 +31,20 @@
     }
     &-error {
       border-color: $destructive;
+    }
+  }
+  &__minimal-input {
+    margin-top: 1.5rem;
+    border: none;
+    border-bottom: 2px solid $brand-color-40;
+    border-radius: 0;
+    transition: 0.1s ease-in-out;
+    &:focus {
+      box-shadow: none;
+      border-bottom-color: $brand-color;
+    }
+    &::placeholder {
+      color: transparent;
     }
   }
   &__password-button {

--- a/src/styles/components/Input.scss
+++ b/src/styles/components/Input.scss
@@ -8,12 +8,16 @@
   &__minimal-label.fd-label {
     position: absolute;
     top: 2rem;
-    color: $brand-color-80;
+    padding-left: 0.75rem;
+    color: $gray-06;
     font-size: 1rem;
+    opacity: 0.8;
     transition: 0.2s ease-in-out;
   }
   &__minimal-label-top-aligned.fd-label {
     top: 0;
+    padding: 0.25rem;
+    color: $gray-15;
     font-size: 0.75rem;
   }
 
@@ -48,7 +52,7 @@
     }
   }
   &__password-button {
-    position:absolute;
+    position: absolute;
     top: 2rem;
     right: 0.5rem;
     display: flex;

--- a/src/styles/components/Label.scss
+++ b/src/styles/components/Label.scss
@@ -1,5 +1,6 @@
 .fd-label {
   margin-bottom: 0.25rem;
   padding-left: 0.25rem;
+  color: $gray-15;
   font-size: 0.75rem;
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -14,6 +14,12 @@ $brand-xx-dark: #0e2c3c !default;
 $brand-black: #050f14 !default;
 $brand-focus-outline: #3178c4 !default;
 
+// Brand alpha colors
+$brand-color-20: rgb(48, 159, 217, 0.2) !default;
+$brand-color-40: rgb(48, 159, 217, 0.4) !default;
+$brand-color-60: rgb(48, 159, 217, 0.6) !default;
+$brand-color-80: rgb(48, 159, 217, 0.8) !default;
+
 // GLASS BRAND
 // Box
 $glass-border: 1px solid rgba(255, 255, 255, 0.18) !default;
@@ -22,7 +28,7 @@ $glass-border: 1px solid rgba(255, 255, 255, 0.18) !default;
 $glass-blur: 7px !default;
 $glass-opacity: 0.25 !default;
 
-// Colors
+// Glass Colors
 $glass-main: rgba(255, 255, 255, $glass-opacity) !default;
 $glass-brand-color: rgba(48, 159, 217, $glass-opacity) !default;
 $glass-brand-hover: rgba(44, 145, 198, $glass-opacity) !default;

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,9 +185,9 @@ export interface InputProps {
   name: string;
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  label: string;
   id?: string;
   type?: string;
-  label?: string;
   placeholder?: string;
   min?: string;
   max?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,19 +182,22 @@ export interface IconArgsType {
 
 //* Input Types
 export interface InputProps {
-  name: string;
-  value: string;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   label: string;
+  name: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+  className?: string;
+  disabled?: boolean;
+  errorMessage?: string;
   id?: string;
-  type?: string;
-  placeholder?: string;
   min?: string;
   max?: string;
-  disabled?: boolean;
-  className?: string;
-  errorMessage?: string;
+  placeholder?: string;
+  type?: string;
+  variant?: InputVariant;
 }
+
+export type InputVariant = 'default' | 'minimal';
 
 //* Navigation Types
 export interface CurrentlyViewingTab {


### PR DESCRIPTION
## Description

Adds show/hide functionality for inputs of type `password`. Adds a new `minimal` variant type input.

- Issues:
  - Resolves #52 #53 

## Changes

**BREAKING**
- Makes `label` on the `Input` component required

**`Input`**
- Adds a show/hide button for `password` inputs
- Adds a `variant` prop and designs the `minimal` input
- Adds `password/minimal` stories
- Refactors story change handlers and names
- Updates tests for `password/minimal`
- Updates `inputCopy`

**Misc**
- Adds `brand-color` alpha style variables
- Adds a default `color` to `Label` styles

## Fixes
- Updates failing tests for `HeaderMenu`
- Removes `font-size` from `Icon` that was overriding styles from consuming components

## Screenshots

**Password Input**
![Input_Password](https://user-images.githubusercontent.com/24458700/108612352-391e0980-73a5-11eb-810e-c8d6de0b77b1.gif)

**Minimal Input**
![Input_Minimal](https://user-images.githubusercontent.com/24458700/108612347-2a375700-73a5-11eb-9132-2d392f21fb1f.gif)

## Sanity Checks

- [x] There are no incidental style changes
