### PR TITLE
Hugh beta release fixes 2

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -26,7 +26,7 @@ jobs:
       # we use exact restore key to avoid NPM module snowballing
       # https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/
       - name: Cache central NPM modules
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -35,7 +35,7 @@ jobs:
 
       # Cache local node_modules to pass to testing jobs
       - name: Cache local node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cache local node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -87,7 +87,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cache local node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -120,7 +120,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cache local node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## Description

The `beta_release` workflow is currently broken due to an issue with `actions/cache`. There is an [ongoing issue](https://github.com/actions/cache/issues/478) tracking others who are having the same problem. This attempts to solve the problem with the latest version of `actions/cache`, version `2.1.4`. If this does not work, we will open a bug ticket to track an update to this workflow for beta releases.

## Changes

- Updates `action/cache@v2.1.4`

## Sanity Checks

- [x] There are no incidental style changes
