### PR TITLE
fix: Updates cron/needs for cypress-tests job

### DIFF
--- a/.github/workflows/scheduled_tests.yml
+++ b/.github/workflows/scheduled_tests.yml
@@ -8,7 +8,7 @@ on:
   # which for this repository is "development"
   schedule:
     # Run this everyday at 08:00
-    - cron: '0 8 * * *'
+    - cron: '0 8,20 * * *'
 
 jobs:
   install:
@@ -83,7 +83,7 @@ jobs:
   cypress-tests:
     name: Run Cypress tests
     runs-on: ubuntu-latest
-    needs: [install, static-analysis]
+    needs: install
     strategy:
       matrix:
         # Each test suite should be listed here for running parallel tests


### PR DESCRIPTION
## Description

## Changes

- Updates schedule to run at 08:00 and 20:00

## Fixes

- Removes `static-analysis` from `cypress-tests` job needs

## Sanity Checks

- [x] There are no incidental style changes
