### PR TITLE
Hugh reveal tests

### DIFF
--- a/src/components/Reveal/Reveal.stories.tsx
+++ b/src/components/Reveal/Reveal.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { withA11y } from '@storybook/addon-a11y';
 
 import { Button } from 'components/Buttons';
+import { revealCopy } from 'shared/data/copyContent';
 import Reveal from './Reveal';
 
 export default {
@@ -21,7 +22,7 @@ export const Default = (): JSX.Element => {
       }}
     >
       <Button variant="brand" onClick={(): void => toggleReveal(!isShown)}>
-        Toggle reveal
+        {revealCopy.toggleButtonText}
       </Button>
 
       <Reveal isShown={isShown} padding="5px">
@@ -30,7 +31,7 @@ export const Default = (): JSX.Element => {
           /* eslint-disable-next-line no-console */
           onClick={(): void => console.log('destroy!')}
         >
-          Secret Destroy Button
+          {revealCopy.hiddenButtonText}
         </Button>
       </Reveal>
     </div>
@@ -47,12 +48,15 @@ export const LargeReveal = (): JSX.Element => {
           variant="brand"
           onClick={(): void => toggleLargeShown(!isLargeShown)}
         >
-          Toggle large reveal
+          {revealCopy.toggleLargeButtonText}
         </Button>
       </div>
 
       <Reveal isShown={isLargeShown}>
-        <img src="https://i.imgflip.com/ohrrn.jpg" alt="All the things" />
+        <img
+          src="https://i.imgflip.com/ohrrn.jpg"
+          alt={revealCopy.imageAltText}
+        />
       </Reveal>
     </div>
   );

--- a/src/cypress/integration/Reveal/reveal-default.spec.ts
+++ b/src/cypress/integration/Reveal/reveal-default.spec.ts
@@ -1,0 +1,21 @@
+import { revealCopy } from 'shared/data/copyContent';
+
+describe('Reveal default tests', () => {
+  before(() => {
+    cy.visitStorybook();
+    cy.loadStory('components-reveal', 'default');
+  });
+
+  it('Should have a toggle button', () => {
+    cy.findByText(revealCopy.toggleButtonText);
+  });
+
+  it('Should not have the hidden button visible', () => {
+    cy.findByText(revealCopy.hiddenButtonText).should('not.be.visible');
+  });
+
+  it('Should reveal the hidden button when clicking the toggle button', () => {
+    cy.findByText(revealCopy.toggleButtonText).click();
+    cy.findByText(revealCopy.hiddenButtonText).should('be.visible');
+  });
+});

--- a/src/cypress/integration/Reveal/reveal-large.spec.ts
+++ b/src/cypress/integration/Reveal/reveal-large.spec.ts
@@ -1,0 +1,21 @@
+import { revealCopy } from 'shared/data/copyContent';
+
+describe('Reveal large tests', () => {
+  before(() => {
+    cy.visitStorybook();
+    cy.loadStory('components-reveal', 'large-reveal');
+  });
+
+  it('Should have a toggle button', () => {
+    cy.findByText(revealCopy.toggleLargeButtonText);
+  });
+
+  it('Should not have the image visible', () => {
+    cy.findByAltText(revealCopy.imageAltText).should('not.be.visible');
+  });
+
+  it('Should reveal the image when clicking the toggle button', () => {
+    cy.findByText(revealCopy.toggleLargeButtonText).click();
+    cy.findByAltText(revealCopy.imageAltText).should('be.visible');
+  });
+});

--- a/src/shared/data/copyContent/index.ts
+++ b/src/shared/data/copyContent/index.ts
@@ -3,6 +3,7 @@ import buttonCopy from './buttonCopy';
 import checkboxCopy from './checkboxCopy';
 import headerMenuCopy from './headerMenuCopy';
 import inputCopy from './inputCopy';
+import revealCopy from './revealCopy';
 import sideNavigationCopy from './sideNavigationCopy';
 
 export {
@@ -11,5 +12,6 @@ export {
   checkboxCopy,
   headerMenuCopy,
   inputCopy,
+  revealCopy,
   sideNavigationCopy,
 };

--- a/src/shared/data/copyContent/revealCopy.ts
+++ b/src/shared/data/copyContent/revealCopy.ts
@@ -1,0 +1,6 @@
+export default {
+  hiddenButtonText: 'Secret Destroy Button',
+  imageAltText: '"All the things"',
+  toggleButtonText: 'Toggle reveal',
+  toggleLargeButtonText: 'Toggle large reveal',
+};

--- a/src/styles/components/Reveal.scss
+++ b/src/styles/components/Reveal.scss
@@ -4,6 +4,13 @@
 .fd-reveal {
   position: relative;
   display: flex;
+  > * {
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+  }
+  &-shown > * {
+    opacity: 1;
+  }
   &__cover,
   &__drawer {
     position: absolute;


### PR DESCRIPTION
## Description

Write `Reveal` component tests and update stories/styles as needed.

- Issues:
  - Resolves #86 

## Changes

- Writes all `Receal` Cypress tests
- Refactors `Reveal` stories to use `revealCopy`

## Fixes

- Updates `Reveal` styles to properly make `children` non-visible when `isShown` property is false

## Sanity Checks

- [x] There are no incidental style changes
