### PR TITLE
Hugh checkbox label

### DIFF
--- a/src/components/Form/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Form/Checkbox/Checkbox.stories.tsx
@@ -47,7 +47,7 @@ export const Disabled = (): JSX.Element => {
   return (
     <div style={{ display: 'flex ' }}>
       <Checkbox
-        label="Label"
+        label={checkboxCopy.disabledLabel}
         /* eslint-disable-next-line no-console */
         onChange={(): void => console.log('Disabled')}
         options={options}

--- a/src/components/Form/Checkbox/Checkbox.tsx
+++ b/src/components/Form/Checkbox/Checkbox.tsx
@@ -27,9 +27,8 @@ const Checkbox: FC<CheckboxProps> = ({
       })}
     >
       {options.map(({ label: optionLabel, checked, disabled }) => (
-        <label
+        <div
           key={`fd-checkbox__${optionLabel}`}
-          htmlFor={optionLabel}
           className={classnames({
             'fd-checkbox__container': true,
             'fd-checkbox__container-disabled': disabled,
@@ -40,7 +39,7 @@ const Checkbox: FC<CheckboxProps> = ({
             className="fd-checkbox__input"
             type="checkbox"
             name={optionLabel}
-            checked={checked}
+            defaultChecked={checked}
             onChange={onChange}
             disabled={disabled}
           />
@@ -53,7 +52,10 @@ const Checkbox: FC<CheckboxProps> = ({
           >
             {checked && <div className="fd-checkbox__icon" />}
           </div>
-          <span>{optionLabel}</span>
+
+          <label htmlFor={optionLabel} className="fd-checkbox__label">
+            {optionLabel}
+          </label>
 
           {optionLabel.toLowerCase() === 'other' && other && (
             <OtherOption
@@ -64,7 +66,7 @@ const Checkbox: FC<CheckboxProps> = ({
               disabled={disabled}
             />
           )}
-        </label>
+        </div>
       ))}
     </div>
 

--- a/src/components/Form/OtherOption/OtherOption.tsx
+++ b/src/components/Form/OtherOption/OtherOption.tsx
@@ -9,6 +9,8 @@ type OtherOptionProps = OtherOptionType & {
   disabled?: boolean;
 };
 
+const OTHER_INPUT_LABEL = 'Other Input';
+
 const OtherOption: FC<OtherOptionProps> = ({
   onChange,
   value,
@@ -16,26 +18,31 @@ const OtherOption: FC<OtherOptionProps> = ({
   selected,
   disabled,
 }: OtherOptionProps) => (
-  <>
-    :
-    <div className="fd-other-option">
-      <input
-        className="fd-other-option__input"
-        type="text"
-        name={name}
-        onChange={onChange}
-        value={value}
-        disabled={disabled}
-      />
-      <span
-        className={classnames({
-          'fd-other-option__underline': true,
-          'fd-other-option__underline-selected': selected,
-          'fd-other-option__underline-disabled': disabled,
-        })}
-      />
-    </div>
-  </>
+  <div className="fd-other-option">
+    <label
+      className="fd-other-option__label"
+      htmlFor={`fd-other-option__${name}`}
+    >
+      {OTHER_INPUT_LABEL}
+    </label>
+
+    <input
+      id={`fd-other-option__${name}`}
+      className="fd-other-option__input"
+      type="text"
+      name={name}
+      onChange={onChange}
+      value={value}
+      disabled={disabled}
+    />
+    <span
+      className={classnames({
+        'fd-other-option__underline': true,
+        'fd-other-option__underline-selected': selected,
+        'fd-other-option__underline-disabled': disabled,
+      })}
+    />
+  </div>
 );
 
 OtherOption.defaultProps = {

--- a/src/cypress/integration/Form/Checkbox/checkbox-disabled.spec.ts
+++ b/src/cypress/integration/Form/Checkbox/checkbox-disabled.spec.ts
@@ -7,24 +7,18 @@ describe('Checkbox Disabled tests', () => {
   });
 
   it('Should be displayed', () => {
-    cy.findByText(checkboxCopy.disabled);
+    cy.findByText(checkboxCopy.disabledLabel);
   });
 
   it('Should have both options disabled', () => {
-    cy.findByText(checkboxCopy.disabled)
-      .siblings('input')
-      .should('be.disabled');
+    cy.findByLabelText(checkboxCopy.disabled).should('be.disabled');
   });
 
   it('Should not have the first option checked', () => {
-    cy.findByText(checkboxCopy.disabled)
-      .siblings('input')
-      .should('not.be.checked');
+    cy.findByLabelText(checkboxCopy.disabled).should('not.be.checked');
   });
 
   it('Should have the second option checked', () => {
-    cy.findByText(checkboxCopy.disabledChecked)
-      .siblings('input')
-      .should('be.checked');
+    cy.findByLabelText(checkboxCopy.disabledChecked).should('be.checked');
   });
 });

--- a/src/cypress/integration/Form/Checkbox/checkbox-with-other-options.spec.ts
+++ b/src/cypress/integration/Form/Checkbox/checkbox-with-other-options.spec.ts
@@ -1,4 +1,4 @@
-import { checkboxCopy } from 'shared/data/copyContent';
+import { checkboxCopy, otherOptionCopy } from 'shared/data/copyContent';
 
 describe('Checkbox With Other Options tests', () => {
   before(() => {
@@ -11,24 +11,16 @@ describe('Checkbox With Other Options tests', () => {
   });
 
   it('Should accept new values in "Other"', () => {
-    // TODO: Update to use findByLabel when Checkbox/OtherOption are refactored
     const expected = 'Strawberry';
 
-    cy.findByText(checkboxCopy.other)
-      .siblings('input')
-      .check({ force: true });
+    cy.findByLabelText(checkboxCopy.other).check({ force: true });
 
-    cy.get('.fd-other-option__input').type(expected);
-
-    cy.get('.fd-other-option__input').should('have.value', expected);
+    cy.findByLabelText(otherOptionCopy.label).type(expected);
+    cy.findByLabelText(otherOptionCopy.label).should('have.value', expected);
   });
 
   it('Should remove value from "Other" if unchecked', () => {
-    // TODO: Update to use findByLabel when Checkbox/OtherOption are refactored
-    cy.get('.fd-other-option')
-      .siblings('input')
-      .uncheck({ force: true });
-
-    cy.get('.fd-other-option__input').should('not.have.value');
+    cy.findByLabelText(checkboxCopy.other).uncheck({ force: true });
+    cy.findByLabelText(otherOptionCopy.label).should('not.have.value');
   });
 });

--- a/src/shared/data/copyContent/checkboxCopy.ts
+++ b/src/shared/data/copyContent/checkboxCopy.ts
@@ -7,6 +7,7 @@ export default {
   cthulhu: 'Cthulhu',
   disabled: 'Disabled',
   disabledChecked: 'Disabled Checked',
+  disabledLabel: 'Disabled Checkboxes',
   dog: 'Dog',
   errorMessage: 'Please pick a favorite pet',
   goldFish: 'Gold Fish',

--- a/src/shared/data/copyContent/index.ts
+++ b/src/shared/data/copyContent/index.ts
@@ -3,6 +3,7 @@ import buttonCopy from './buttonCopy';
 import checkboxCopy from './checkboxCopy';
 import headerMenuCopy from './headerMenuCopy';
 import inputCopy from './inputCopy';
+import otherOptionCopy from './otherOptionCopy';
 import revealCopy from './revealCopy';
 import sideNavigationCopy from './sideNavigationCopy';
 import textareaCopy from './textareaCopy';
@@ -13,6 +14,7 @@ export {
   checkboxCopy,
   headerMenuCopy,
   inputCopy,
+  otherOptionCopy,
   revealCopy,
   sideNavigationCopy,
   textareaCopy,

--- a/src/shared/data/copyContent/otherOptionCopy.ts
+++ b/src/shared/data/copyContent/otherOptionCopy.ts
@@ -1,0 +1,3 @@
+export default {
+  label: 'Other Input',
+};

--- a/src/styles/components/Checkbox.scss
+++ b/src/styles/components/Checkbox.scss
@@ -60,4 +60,8 @@
   &__icon {
     @include check-mark-animation(0.2rem, 0.5rem, 0.125rem);
   }
+  &__label {
+    position: absolute;
+    padding-left: 1.65rem;
+  }
 }

--- a/src/styles/components/OtherOption.scss
+++ b/src/styles/components/OtherOption.scss
@@ -4,6 +4,9 @@
 .fd-other-option {
   position: relative;
   margin-right: 0.5rem;
+  &__label {
+    @include hide-visually();
+  }
   &__input {
     position: relative;
     max-width: 16.75rem;


### PR DESCRIPTION
## Description

Updates the `Checkbox` and `OtherOption` components to use an accessible `label` element for each `input`.

- Issues:
  - Resolves #92 

## Changes

- Updates `Checkbox` tests to use `findByLabel`

## Fixes

- Adds semantic `label` elements to `Checkbox/OtherOption` components
- Fixes resulting style issues
- Updates missing copy content for `Checkbox` stories

## Sanity Checks

- [x] There are no incidental style changes
