### PR TITLE
Test PR workflow tweaks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -115,9 +115,9 @@ jobs:
         # Each test suite should be listed here for running parallel tests
         # You may see an error here from your IDE because it does not recognize this
         # environment variable as an array, even though it is by the time it is set
-        # test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
+        test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
         # Multiple machines are used for load balancing
-        machines: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        machines: [1, 2]
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -149,13 +149,13 @@ jobs:
           npx cypress cache path
           npx cypress cache list
 
-      - name: Run Cypress tests
+      - name: Run ${{ matrix.test-suite }} Cypress tests
         uses: cypress-io/github-action@v2
         with:
-          # spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
+          spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
           browser: chrome
           start: yarn storybook --ci
-          # group: "${{ matrix.test-suite }} Tests"
+          group: "${{ matrix.test-suite }} Tests"
           record: true
           parallel: true
           # tag will be either "push" or "pull_request"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,9 +16,6 @@ jobs:
   install:
     name: Install and cache dependencies
     runs-on: ubuntu-latest
-    outputs:
-      # We output the test-suites here to it's accessible to other jobs
-      test-suites: ${{ steps.get-test-suites.outputs.directory-names }}
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -26,17 +23,6 @@ jobs:
           # Removes credentials
           persist-credentials: false
           fetch-depth: 0
-
-      - name: Get test suite directories
-        id: get-test-suites
-        # Custom action that grabs all of our existing test-suites
-        uses: featherweight-design/collect-directory-names-by-file-glob@v1.2.2
-        with:
-          file-glob: "**/*.spec.ts"
-          search-directory: "/src/cypress"
-
-      - name: Check test suite directories
-        run: echo "Directories are ${{ steps.get-test-suites.outputs.directory-names }}"
 
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
@@ -112,12 +98,8 @@ jobs:
     needs: [install, static-analysis]
     strategy:
       matrix:
-        # Each test suite should be listed here for running parallel tests
-        # You may see an error here from your IDE because it does not recognize this
-        # environment variable as an array, even though it is by the time it is set
-        # test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
         # Multiple machines are used for load balancing
-        machines: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        machines: [1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -152,10 +134,8 @@ jobs:
       - name: Run Cypress tests
         uses: cypress-io/github-action@v2
         with:
-          # spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
           browser: chrome
           start: yarn storybook --ci
-          # group: "${{ matrix.test-suite }} Tests"
           record: true
           parallel: true
           # tag will be either "push" or "pull_request"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -115,9 +115,9 @@ jobs:
         # Each test suite should be listed here for running parallel tests
         # You may see an error here from your IDE because it does not recognize this
         # environment variable as an array, even though it is by the time it is set
-        test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
+        # test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
         # Multiple machines are used for load balancing
-        machines: [1, 2, 3, 4, 5, 6, 7]
+        machines: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -149,13 +149,13 @@ jobs:
           npx cypress cache path
           npx cypress cache list
 
-      - name: Run ${{ matrix.test-suite }} Cypress tests
+      - name: Run Cypress tests
         uses: cypress-io/github-action@v2
         with:
-          spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
+          # spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
           browser: chrome
           start: yarn storybook --ci
-          group: "${{ matrix.test-suite }} Tests"
+          # group: "${{ matrix.test-suite }} Tests"
           record: true
           parallel: true
           # tag will be either "push" or "pull_request"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -117,7 +117,7 @@ jobs:
         # environment variable as an array, even though it is by the time it is set
         # test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
         # Multiple machines are used for load balancing
-        machines: [1, 2, 3, 4, 5, 6]
+        machines: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     steps:
       - name: Checkout code
         uses: actions/checkout@master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -115,9 +115,9 @@ jobs:
         # Each test suite should be listed here for running parallel tests
         # You may see an error here from your IDE because it does not recognize this
         # environment variable as an array, even though it is by the time it is set
-        test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
+        # test-suite: ${{ fromJson(needs.install.outputs.test-suites) }}
         # Multiple machines are used for load balancing
-        machines: [1, 2]
+        machines: [1, 2, 3, 4, 5, 6]
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -149,13 +149,13 @@ jobs:
           npx cypress cache path
           npx cypress cache list
 
-      - name: Run ${{ matrix.test-suite }} Cypress tests
+      - name: Run Cypress tests
         uses: cypress-io/github-action@v2
         with:
-          spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
+          # spec: src/cypress/integration/**/${{ matrix.test-suite }}/*.spec.ts
           browser: chrome
           start: yarn storybook --ci
-          group: "${{ matrix.test-suite }} Tests"
+          # group: "${{ matrix.test-suite }} Tests"
           record: true
           parallel: true
           # tag will be either "push" or "pull_request"


### PR DESCRIPTION
## Description

Updates PR workflow to optimize Cypress run parallelization by removing `test-suites` from the matric configuration. This was resulting in long test times for a number of reasons:

- Some components had more tests but had the same number of machines (i.e. inefficient test load balancing)
- Components with fewer tests would occasionally run a machine with no tests which were resulting in wasted resources and, sometimes, errors from no results in a given machine

## Changes

- Removes `test-suites` from matrix configuration and any associated workflow steps
- Increases total shared machines from `7` to `9`

## Fixes

- Decreases overall test run time by removing `test-suites` matrix configuration

## Sanity Checks

- [x] There are no incidental style changes
