### PR TITLE
fix: Alpha color variables

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -15,10 +15,10 @@ $brand-black: #050f14 !default;
 $brand-focus-outline: #3178c4 !default;
 
 // Brand alpha colors
-$brand-color-20: rgb(48, 159, 217, 0.2) !default;
-$brand-color-40: rgb(48, 159, 217, 0.4) !default;
-$brand-color-60: rgb(48, 159, 217, 0.6) !default;
-$brand-color-80: rgb(48, 159, 217, 0.8) !default;
+$brand-color-20: rgba(48, 159, 217, 0.2) !default;
+$brand-color-40: rgba(48, 159, 217, 0.4) !default;
+$brand-color-60: rgba(48, 159, 217, 0.6) !default;
+$brand-color-80: rgba(48, 159, 217, 0.8) !default;
 
 // GLASS BRAND
 // Box


### PR DESCRIPTION
## Description

Alpha brand colors were using `rgb` instead of `rgba` which caused a compilation error.

## Fixes

- Update all alpha SCSS `variables` to use `rgba`

## Sanity Checks

- [x] There are no incidental style changes
